### PR TITLE
Feature: Validate `dmon` parser against real gpu output

### DIFF
--- a/src/agi/safety/dcgm_attestation.py
+++ b/src/agi/safety/dcgm_attestation.py
@@ -77,8 +77,6 @@ class GPUSnapshot:
     ecc_sbe: int  # single-bit (corrected) ECC errors
     ecc_dbe: int  # double-bit (uncorrected) ECC errors
     memory_used_mib: int
-    pcie_tx_bytes: int
-    pcie_rx_bytes: int
     raw: dict[str, Any] = field(default_factory=dict)
 
     @property
@@ -165,14 +163,14 @@ class DCGMAttestor:
 
         try:
             # dcgmi dmon: one-shot sample of key fields
-            # Fields: SM util, mem util, power, temp, ECC SBE/DBE total,
-            #         FB used, PCIe TX/RX
+            # Fields: SM util (203), mem util (204), power (155),
+            #         temp (150), ECC SBE (310), ECC DBE (311), FB used (252)
             out = subprocess.check_output(
                 [
                     self._dcgmi,
                     "dmon",
                     "-e",
-                    "203,204,150,140,310,311,252,253,254",
+                    "203,204,155,150,310,311,252",
                     "-c",
                     "1",
                     "-d",
@@ -316,8 +314,6 @@ class DCGMAttestor:
             ecc_sbe=0,
             ecc_dbe=0,
             memory_used_mib=0,
-            pcie_tx_bytes=0,
-            pcie_rx_bytes=0,
         )
 
     def _parse_dmon(self, raw_output: str) -> GPUSnapshot:
@@ -328,18 +324,20 @@ class DCGMAttestor:
             if not line or line.startswith("#") or line.startswith("Entity"):
                 continue
             parts = line.split()
+            # Skip unit-annotation lines (e.g. "ID    W    C")
+            if parts[0] == "ID":
+                continue
             # dcgmi dmon prefixes each data line with "GPU <idx>",
             # so skip the entity identifier columns.
-            offset = 0
-            for i, p in enumerate(parts):
-                if p.replace(".", "").replace("-", "").isdigit() or p in ("N/A", "*"):
-                    offset = i
-                    break
-            if len(parts) - offset < 9:
+            if parts[0] == "GPU" and len(parts) > 1:
+                offset = 2
+            else:
+                offset = 0
+            if len(parts) - offset < 7:
                 continue
             # Fields in order of -e flag:
-            # sm_util, mem_util, power, temp, ecc_sbe, ecc_dbe,
-            # fb_used, pcie_tx, pcie_rx
+            # 203=sm_util, 204=mem_util, 155=power, 150=temp,
+            # 310=ecc_sbe, 311=ecc_dbe, 252=fb_used
             try:
                 o = offset
                 values = {
@@ -350,8 +348,6 @@ class DCGMAttestor:
                     "ecc_sbe": self._safe_int(parts[o + 4]),
                     "ecc_dbe": self._safe_int(parts[o + 5]),
                     "memory_used_mib": self._safe_int(parts[o + 6]),
-                    "pcie_tx_bytes": self._safe_int(parts[o + 7]),
-                    "pcie_rx_bytes": self._safe_int(parts[o + 8]),
                 }
             except (IndexError, ValueError):
                 continue

--- a/tests/fixtures/dcgm_dmon_rtx2080ti.txt
+++ b/tests/fixtures/dcgm_dmon_rtx2080ti.txt
@@ -1,0 +1,7 @@
+#Entity   GPUTL             MCUTL             POWER             TMPTR        ESVTL        EDVTL        FBUSD
+ID                                             W                 C
+GPU 0     0                 0                 20.891            22           0            0            0
+GPU 0     0                 0                 20.891            22           0            0            0
+GPU 0     0                 0                 20.891            22           0            0            0
+GPU 0     0                 0                 20.986            22           0            0            0
+GPU 0     0                 0                 20.986            22           0            0            0

--- a/tests/test_dcgm_attestation.py
+++ b/tests/test_dcgm_attestation.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import time
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -41,8 +42,6 @@ def _snap(
         ecc_sbe=ecc_sbe,
         ecc_dbe=ecc_dbe,
         memory_used_mib=mem_used,
-        pcie_tx_bytes=0,
-        pcie_rx_bytes=0,
         **kw,
     )
 
@@ -158,9 +157,11 @@ class TestSnapshot:
         assert snap.sm_utilization == 0.0
 
     def test_parses_dmon_output(self, attestor):
+        # Real dcgmi dmon output format (validated on Nautilus GPU node)
         sample_output = (
-            "# Entity   SMUTIL MEMUTIL POWER  TEMP  ECCSBE ECCDBE FBUSED  PCIETX  PCIERX\n"
-            "  GPU 0    75     42      185.3  68    0      0      28456   123456  654321\n"
+            "#Entity   GPUTL             MCUTL             POWER             TMPTR        ESVTL        EDVTL        FBUSD             \n"
+            "ID                                             W                 C                                                       \n"
+            "GPU 0     75                42                185.300           68           0            0            28456             \n"
         )
         snap = attestor._parse_dmon(sample_output)
         assert snap.sm_utilization == 75.0
@@ -171,10 +172,30 @@ class TestSnapshot:
         assert snap.ecc_dbe == 0
         assert snap.memory_used_mib == 28456
 
+    def test_parses_real_rtx2080ti_fixture(self, attestor):
+        """Parse real dcgmi dmon output captured on RTX 2080 Ti (Turing).
+
+        GPU: NVIDIA GeForce RTX 2080 Ti, driver 590.48.01
+        DCGM: 3.3.5, captured on NRP Nautilus Kubernetes cluster.
+        Command: dcgmi dmon -e 203,204,155,150,310,311,252 -c 5 -d 1
+        """
+        fixture = Path(__file__).parent / "fixtures" / "dcgm_dmon_rtx2080ti.txt"
+        raw = fixture.read_text()
+        snap = attestor._parse_dmon(raw)
+        # Last sample wins (parser overwrites on each data line)
+        assert snap.sm_utilization == 0.0
+        assert snap.memory_utilization == 0.0
+        assert snap.power_draw_w == 20.986
+        assert snap.temperature_c == 22.0
+        assert snap.ecc_sbe == 0
+        assert snap.ecc_dbe == 0
+        assert snap.memory_used_mib == 0
+
     def test_handles_na_values(self, attestor):
         sample_output = (
-            "# header\n"
-            "  GPU 0    N/A    N/A     N/A    N/A   N/A    N/A    N/A     N/A     N/A\n"
+            "#Entity   GPUTL             MCUTL             POWER             TMPTR        ESVTL        EDVTL        FBUSD             \n"
+            "ID                                             W                 C                                                       \n"
+            "GPU 0     N/A               N/A               N/A               N/A          N/A          N/A          N/A               \n"
         )
         snap = attestor._parse_dmon(sample_output)
         assert snap.sm_utilization == 0.0


### PR DESCRIPTION
Addresses issue #73 

This PR tested the output of the `dcgmi dmon` commands on the NVIDIA GeForce RTX 2080 Ti (Turing), driver 590.48.01, DCGM 3.3.5 GPU, on NRP Nautilus. 

What was fixed:
- [ ] **-e flags** — Changed from `203,204,150,140,310,311,252,253,254` to `203,204,155,150,310,311,252`. The original flags had temperature (150) in the power slot and never requested power (155) at all, which broke the `attest()` resource-match check.
- [ ] **Dropped PCIe fields** — The original flags 253/254 mapped to FB reserved/FB used %, not PCIe TX/RX. PCIe throughput IDs aren't reliably available across architectures, and no attestation check uses them.
- [ ] **Parser offset logic** — The heuristic digit-finder landed on 0 in GPU 0, misaligning all columns. Replaced with explicit GPU prefix detection.
- [ ] **ID line skip** — The unit-annotation line (ID   W   C) wasn't filtered out and could be misparsed as data.

To run the revised test: `python -m pytest tests/test_dcgm_attestation.py -v 2>&1`