### PR TITLE
artemis: phase 3.5 — HUD avatar + web UI + sprint plan

### DIFF
--- a/deploy/systemd/atlas-artemis-avatar.service
+++ b/deploy/systemd/atlas-artemis-avatar.service
@@ -1,0 +1,36 @@
+[Unit]
+Description=Atlas ARTEMIS Avatar Agent — HUD video + Piper TTS on LiveKit
+Documentation=file:///home/claude/agi-hpc/docs/ARTEMIS_AVATAR_ROADMAP.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=claude
+WorkingDirectory=/home/claude
+Environment=PYTHONUNBUFFERED=1
+EnvironmentFile=-/home/claude/.artemis-avatar.env
+Environment=LIVEKIT_URL=ws://127.0.0.1:7880
+Environment=LIVEKIT_API_KEY=devkey
+Environment=LIVEKIT_API_SECRET=secret
+Environment=ARTEMIS_ROOM=smoke-test
+Environment=ARTEMIS_IDENTITY=artemis
+Environment=ARTEMIS_VOICE=/home/claude/piper-voices/en_US-amy-medium.onnx
+ExecStart=/home/claude/venvs/artemis-avatar/bin/python3 -m agi.primer.artemis.livekit_agent.avatar_hud
+
+Restart=on-failure
+RestartSec=10
+StartLimitIntervalSec=600
+StartLimitBurst=5
+
+KillSignal=SIGTERM
+TimeoutStopSec=30
+
+StandardOutput=journal
+StandardError=journal
+
+MemoryMax=2G
+CPUQuota=100%
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/web/table/index.html
+++ b/deploy/web/table/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>ARTEMIS · Nithon Table</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<link rel="stylesheet" href="./table.css" />
+</head>
+<body>
+  <div id="app">
+    <!-- Avatar card: full-height left column -->
+    <section id="card-avatar" class="card">
+      <header class="card-header">
+        <span class="card-label">AVATAR</span>
+        <span id="avatar-status" class="card-status">—</span>
+      </header>
+      <div id="avatar-stage">
+        <video id="artemis-video" autoplay playsinline muted></video>
+        <div id="avatar-placeholder" class="avatar-placeholder">
+          <div class="pulse"></div>
+          <div class="placeholder-text">CONNECTING…</div>
+        </div>
+      </div>
+      <div class="avatar-controls">
+        <button id="mic-btn" class="btn">MIC: OFF</button>
+        <button id="leave-btn" class="btn danger">DISCONNECT</button>
+      </div>
+    </section>
+
+    <!-- Right column: two stacked cards -->
+    <div class="right-column">
+      <!-- Info / HUD card -->
+      <section id="card-info" class="card">
+        <header class="card-header">
+          <span class="card-label">SESSION</span>
+          <span id="clock">--:--:--</span>
+        </header>
+        <div class="info-block">
+          <div class="info-row">
+            <span class="info-k">ROOM</span>
+            <span id="info-room" class="info-v">—</span>
+          </div>
+          <div class="info-row">
+            <span class="info-k">IDENTITY</span>
+            <span id="info-identity" class="info-v">—</span>
+          </div>
+          <div class="info-row">
+            <span class="info-k">STATUS</span>
+            <span id="info-status" class="info-v">OFFLINE</span>
+          </div>
+        </div>
+        <div class="participants-block">
+          <div class="block-title">PARTICIPANTS</div>
+          <ul id="participants" class="list"></ul>
+        </div>
+        <div class="log-block">
+          <div class="block-title">EVENT LOG</div>
+          <ul id="event-log" class="list log"></ul>
+        </div>
+      </section>
+
+      <!-- Artifacts card -->
+      <section id="card-artifacts" class="card">
+        <header class="card-header">
+          <span class="card-label">ARTIFACTS</span>
+          <span class="card-status">SESSION HANDOUTS</span>
+        </header>
+        <ul id="artifact-list" class="list">
+          <li class="loading">loading manifest…</li>
+        </ul>
+      </section>
+    </div>
+  </div>
+
+  <script src="./vendor/livekit-client.umd.min.js"></script>
+  <script src="./table.js"></script>
+</body>
+</html>

--- a/deploy/web/table/table.css
+++ b/deploy/web/table/table.css
@@ -1,0 +1,321 @@
+/* ARTEMIS table UI — amber-on-black terminal.
+   Kept deliberately dense and angular; matches the handheld-device
+   aesthetic of the in-fiction ARTEMIS. */
+
+:root {
+  --bg: #06060a;
+  --card-bg: #0c0c14;
+  --amber: #ffb030;
+  --amber-dim: #804518;
+  --amber-deep: #3c2404;
+  --cyan: #50dcf0;
+  --cyan-dim: #1e6e82;
+  --white-dim: #b4b4c8;
+  --grid: #1a1a26;
+  --danger: #c84830;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html, body {
+  height: 100%;
+  font-family: "SF Mono", "Consolas", "DejaVu Sans Mono", ui-monospace, monospace;
+  background: var(--bg);
+  color: var(--amber);
+  font-size: 13px;
+  overflow: hidden;
+  /* Faint grid */
+  background-image:
+    linear-gradient(var(--grid) 1px, transparent 1px),
+    linear-gradient(90deg, var(--grid) 1px, transparent 1px);
+  background-size: 32px 32px;
+}
+
+#app {
+  display: grid;
+  grid-template-columns: 1.3fr 1fr;
+  gap: 12px;
+  padding: 12px;
+  height: 100vh;
+}
+
+.right-column {
+  display: grid;
+  grid-template-rows: 1.4fr 1fr;
+  gap: 12px;
+  min-height: 0;
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--amber-dim);
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  box-shadow: inset 0 0 0 1px rgba(255, 176, 48, 0.06);
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 14px;
+  background: rgba(255, 176, 48, 0.05);
+  border-bottom: 1px solid var(--amber-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  font-size: 11px;
+  color: var(--amber);
+}
+
+.card-label {
+  font-weight: bold;
+}
+
+.card-status {
+  color: var(--amber-dim);
+}
+
+/* ── Avatar card ─────────────────────────────────────────────── */
+
+#card-avatar {
+  position: relative;
+}
+
+#avatar-stage {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+  background: #000;
+}
+
+#artemis-video {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  background: #000;
+}
+
+#artemis-video:not([data-connected="true"]) {
+  display: none;
+}
+
+.avatar-placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  color: var(--amber-dim);
+}
+
+.avatar-placeholder[hidden] {
+  display: none;
+}
+
+.pulse {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  border: 2px solid var(--amber);
+  animation: pulse 2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { transform: scale(1); opacity: 0.4; }
+  50% { transform: scale(1.2); opacity: 0.8; }
+}
+
+.placeholder-text {
+  letter-spacing: 0.3em;
+  font-size: 12px;
+  text-transform: uppercase;
+}
+
+.avatar-controls {
+  display: flex;
+  gap: 8px;
+  padding: 10px 14px;
+  border-top: 1px solid var(--amber-dim);
+}
+
+.btn {
+  background: transparent;
+  border: 1px solid var(--amber-dim);
+  color: var(--amber);
+  padding: 6px 14px;
+  font-family: inherit;
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.btn:hover {
+  border-color: var(--amber);
+  background: rgba(255, 176, 48, 0.08);
+}
+
+.btn.danger {
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+.btn.danger:hover {
+  background: rgba(200, 72, 48, 0.12);
+}
+
+.btn.active {
+  background: rgba(80, 220, 240, 0.12);
+  border-color: var(--cyan);
+  color: var(--cyan);
+}
+
+/* ── Info card ───────────────────────────────────────────────── */
+
+#clock {
+  color: var(--amber-dim);
+  font-variant-numeric: tabular-nums;
+}
+
+.info-block {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--grid);
+  font-size: 12px;
+}
+
+.info-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 3px 0;
+}
+
+.info-k {
+  color: var(--amber-dim);
+  letter-spacing: 0.1em;
+}
+
+.info-v {
+  color: var(--amber);
+  font-weight: bold;
+}
+
+.participants-block,
+.log-block {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--grid);
+  overflow: hidden;
+  min-height: 0;
+}
+
+.log-block {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.block-title {
+  font-size: 10px;
+  letter-spacing: 0.3em;
+  color: var(--amber-dim);
+  margin-bottom: 6px;
+}
+
+.list {
+  list-style: none;
+  font-size: 12px;
+}
+
+.list li {
+  padding: 3px 0;
+  color: var(--white-dim);
+}
+
+.list li.you {
+  color: var(--cyan);
+}
+
+.list li.active {
+  color: var(--amber);
+  font-weight: bold;
+}
+
+.list li.artemis {
+  color: var(--amber);
+}
+
+.list.log li {
+  font-size: 11px;
+  color: var(--amber-dim);
+  font-variant-numeric: tabular-nums;
+}
+
+.list.log li:last-child {
+  color: var(--amber);
+}
+
+/* ── Artifacts card ──────────────────────────────────────────── */
+
+#card-artifacts .list {
+  padding: 8px 14px;
+  overflow-y: auto;
+}
+
+.list li.artifact {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 0;
+  border-bottom: 1px dotted var(--grid);
+  color: var(--amber);
+}
+
+.list li.artifact a {
+  color: var(--cyan);
+  text-decoration: none;
+  padding: 2px 10px;
+  border: 1px solid var(--cyan-dim);
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.list li.artifact a:hover {
+  color: var(--cyan);
+  border-color: var(--cyan);
+  background: rgba(80, 220, 240, 0.08);
+}
+
+.list li.loading {
+  color: var(--amber-dim);
+  font-style: italic;
+}
+
+/* ── Scrollbar styling ───────────────────────────────────────── */
+
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--amber-dim);
+  border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--amber);
+}

--- a/deploy/web/table/table.js
+++ b/deploy/web/table/table.js
@@ -1,0 +1,208 @@
+// ARTEMIS table — LiveKit client + HUD state.
+// No framework; plain DOM. Token + room name come from URL params.
+
+(function () {
+  "use strict";
+
+  const qs = new URLSearchParams(window.location.search);
+  const token = qs.get("t") || qs.get("token") || "";
+  const roomName = qs.get("room") || window.location.pathname.split("/").pop() || "";
+  const serverUrl = qs.get("server") || "wss://atlas-sjsu.duckdns.org/livekit";
+
+  const $ = (id) => document.getElementById(id);
+
+  const state = {
+    room: null,
+    localIdentity: null,
+    micOn: false,
+    startedAt: Date.now(),
+  };
+
+  // ── tick clock ──────────────────────────────────────────────
+  setInterval(() => {
+    const d = new Date();
+    $("clock").textContent = d.toLocaleTimeString("en-GB", {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+  }, 500);
+
+  function log(text, klass) {
+    const li = document.createElement("li");
+    const t = new Date().toLocaleTimeString("en-GB", { hour12: false });
+    li.textContent = `${t}  ${text}`;
+    if (klass) li.className = klass;
+    const list = $("event-log");
+    list.appendChild(li);
+    while (list.children.length > 20) list.removeChild(list.firstChild);
+    list.scrollTop = list.scrollHeight;
+  }
+
+  function renderParticipants() {
+    const list = $("participants");
+    list.innerHTML = "";
+    if (!state.room) return;
+    const all = [state.room.localParticipant, ...state.room.remoteParticipants.values()];
+    for (const p of all) {
+      const li = document.createElement("li");
+      const isYou = p.identity === state.localIdentity;
+      const isArtemis = p.identity === "artemis";
+      const isActive = p.isSpeaking;
+      li.textContent =
+        (isArtemis ? "◆ " : isYou ? "▸ " : "· ") +
+        p.identity +
+        (isYou ? "  (you)" : "") +
+        (isArtemis ? "  (ai)" : "");
+      if (isYou) li.classList.add("you");
+      if (isArtemis) li.classList.add("artemis");
+      if (isActive) li.classList.add("active");
+      list.appendChild(li);
+    }
+  }
+
+  async function loadArtifacts() {
+    const list = $("artifact-list");
+    list.innerHTML = "";
+    try {
+      const res = await fetch("/artifacts/manifest.json?session=" + encodeURIComponent(roomName));
+      const items = await res.json();
+      if (!items.length) {
+        const li = document.createElement("li");
+        li.className = "loading";
+        li.textContent = "no artifacts available";
+        list.appendChild(li);
+        return;
+      }
+      for (const it of items) {
+        const li = document.createElement("li");
+        li.className = "artifact";
+        const left = document.createElement("span");
+        left.textContent = it.title;
+        const a = document.createElement("a");
+        a.href = it.href;
+        a.target = "_blank";
+        a.rel = "noopener";
+        a.textContent = "download";
+        li.appendChild(left);
+        li.appendChild(a);
+        list.appendChild(li);
+      }
+    } catch (err) {
+      const li = document.createElement("li");
+      li.className = "loading";
+      li.textContent = "artifact service unavailable";
+      list.appendChild(li);
+    }
+  }
+
+  async function connect() {
+    if (!token) {
+      log("no token in URL — pass ?t=<jwt>", "err");
+      $("info-status").textContent = "NO TOKEN";
+      return;
+    }
+    if (!window.LivekitClient) {
+      log("livekit-client not loaded", "err");
+      return;
+    }
+
+    $("info-room").textContent = roomName || "(from token)";
+    $("info-status").textContent = "CONNECTING";
+
+    const room = new LivekitClient.Room({
+      adaptiveStream: true,
+      dynacast: true,
+    });
+    state.room = room;
+
+    room.on(LivekitClient.RoomEvent.ParticipantConnected, (p) => {
+      log("join: " + p.identity);
+      renderParticipants();
+    });
+    room.on(LivekitClient.RoomEvent.ParticipantDisconnected, (p) => {
+      log("leave: " + p.identity);
+      renderParticipants();
+    });
+    room.on(LivekitClient.RoomEvent.ActiveSpeakersChanged, (speakers) => {
+      renderParticipants();
+      const names = speakers.map((s) => s.identity);
+      $("avatar-status").textContent =
+        names.length === 0 ? "IDLE" :
+        names.includes("artemis") ? "ARTEMIS SPEAKING" :
+        "HEARING " + names[0];
+    });
+    room.on(LivekitClient.RoomEvent.TrackSubscribed, (track, pub, p) => {
+      log("track: " + p.identity + "/" + track.kind);
+      if (p.identity === "artemis" && track.kind === "video") {
+        const el = $("artemis-video");
+        track.attach(el);
+        el.dataset.connected = "true";
+        $("avatar-placeholder").hidden = true;
+      }
+      if (track.kind === "audio") {
+        const el = track.attach();
+        el.autoplay = true;
+        document.body.appendChild(el);
+      }
+    });
+    room.on(LivekitClient.RoomEvent.DataReceived, (payload, p) => {
+      try {
+        const parsed = JSON.parse(new TextDecoder().decode(payload));
+        if (parsed.kind === "artemis.say") {
+          log("ARTEMIS: " + parsed.text);
+        }
+      } catch (_) {
+        /* ignore non-JSON data */
+      }
+    });
+    room.on(LivekitClient.RoomEvent.Disconnected, (reason) => {
+      log("disconnected: " + (reason || ""));
+      $("info-status").textContent = "DISCONNECTED";
+    });
+
+    try {
+      await room.connect(serverUrl, token);
+      state.localIdentity = room.localParticipant.identity;
+      $("info-identity").textContent = state.localIdentity;
+      $("info-status").textContent = "CONNECTED";
+      log("connected as " + state.localIdentity);
+      renderParticipants();
+      // Enable mic by default (can toggle with button).
+      try {
+        await room.localParticipant.setMicrophoneEnabled(true);
+        state.micOn = true;
+        $("mic-btn").textContent = "MIC: ON";
+        $("mic-btn").classList.add("active");
+      } catch (_) {
+        log("mic not available (permission denied?)");
+      }
+    } catch (err) {
+      log("connect failed: " + err.message, "err");
+      $("info-status").textContent = "ERROR";
+      $("avatar-status").textContent = "FAIL";
+    }
+  }
+
+  $("mic-btn").addEventListener("click", async () => {
+    if (!state.room) return;
+    state.micOn = !state.micOn;
+    await state.room.localParticipant.setMicrophoneEnabled(state.micOn);
+    $("mic-btn").textContent = state.micOn ? "MIC: ON" : "MIC: OFF";
+    $("mic-btn").classList.toggle("active", state.micOn);
+  });
+
+  $("leave-btn").addEventListener("click", async () => {
+    if (state.room) await state.room.disconnect();
+    state.room = null;
+    $("artemis-video").removeAttribute("data-connected");
+    $("avatar-placeholder").hidden = false;
+    renderParticipants();
+  });
+
+  // ── kickoff ─────────────────────────────────────────────────
+  document.addEventListener("DOMContentLoaded", () => {
+    loadArtifacts();
+    connect();
+  });
+})();

--- a/deploy/web/table/vendor/README.md
+++ b/deploy/web/table/vendor/README.md
@@ -1,0 +1,16 @@
+# vendored JS deps
+
+`livekit-client.umd.min.js` is expected here (bundled locally so the
+page doesn't depend on unpkg at runtime).
+
+Fetch once on Atlas during deploy:
+
+```bash
+curl -o /home/claude/atlas-web/table/vendor/livekit-client.umd.min.js \
+  https://unpkg.com/livekit-client@2/dist/livekit-client.umd.min.js
+```
+
+Committing the minified UMD itself to the repo is a judgment call —
+in this repo we don't commit vendored minified libs, so the file is
+downloaded at deploy time by the deploy script instead. See the
+Phase A section of `docs/ARTEMIS_AVATAR_ROADMAP.md`.

--- a/docs/ARTEMIS_AVATAR_ROADMAP.md
+++ b/docs/ARTEMIS_AVATAR_ROADMAP.md
@@ -1,0 +1,281 @@
+# ARTEMIS Avatar Roadmap
+
+This document plans the evolution of the ARTEMIS in-room presence from
+the scaffolded Phase 3 LiveKit agent into the production vision: a
+browser-rendered humanoid 3D avatar + custom game-table UI + on-demand
+player artifacts.
+
+Companion to [`ARTEMIS.md`](ARTEMIS.md). The Phase 1 handler, Phase 2
+NATS wiring, and Phase 3 LiveKit-agent skeleton are already on `main`.
+This roadmap picks up from there.
+
+---
+
+## Status (2026-04-23)
+
+**Already landed:**
+- Phase 1 — offline `handle_turn`, validator, DecisionProof chain (72 unit tests)
+- Phase 2 — `ArtemisService` NATS handler, systemd unit, 20-turn e2e
+- Phase 3 — LiveKit agent package skeleton, JWT minting, Dockerfile
+  scaffolding
+
+**Experiment running tonight on Atlas:**
+- v4 avatar agent (`artemis_avatar.py`) publishes an icosahedron-HUD
+  video track + Piper TTS audio + canned-response responder. Out-of-tree
+  under `/home/claude/` pending the Phase 3.5 commit below.
+
+**Validated end-to-end:**
+- Browser can reach Atlas's LiveKit via `wss://atlas-sjsu.duckdns.org/livekit`
+- TTS (Piper + Amy female voice) publishes cleanly
+- Room participants see ARTEMIS as a video participant
+
+---
+
+## Phase 3.5 — Consolidate the experiment into the repo
+
+**Goal:** move the working experiment out of `/home/claude/` and into
+version control so nothing's lost and the Phase 3 skeleton is replaced
+by something that actually runs.
+
+**Scope:**
+- `src/agi/primer/artemis/livekit_agent/avatar_hud.py` — the HUD-based
+  avatar agent (replaces the Zoom-era stub).
+- `deploy/systemd/atlas-artemis-avatar.service` — systemd unit.
+- Unit tests for the rendering + responder logic (no LiveKit in tests).
+- Update `docs/ARTEMIS.md` §11 Phase 3 to reflect that the agent is
+  real code now, not scaffolding.
+
+**Done when:**
+- Tests pass on CI
+- `atlas-artemis-avatar.service` can be enabled on Atlas to reproduce
+  the running experiment
+- No code lives outside the repo
+
+---
+
+## Phase A — Custom game-table web UI
+
+**Goal:** replace `meet.livekit.io` with our own browser UI at
+`https://atlas-sjsu.duckdns.org/table/<session_id>`. Three-card layout:
+avatar (left), info/HUD (top-right), artifacts (bottom-right).
+
+**Scope:**
+
+```
+deploy/web/table/
+├── index.html        — three-card layout, query-string token
+├── table.css         — amber-on-black terminal styling
+├── table.js          — LiveKit connection, HUD state, chat
+└── vendor/
+    └── livekit-client.umd.min.js   — bundled locally, not CDN
+```
+
+**Cards:**
+
+- **AVATAR** (left, ~55 % width) — subscribes to the `artemis` video
+  track from LiveKit. In v1 this is the Python-rendered HUD; in Phase
+  B it will be replaced by a browser-rendered 3D scene.
+- **INFO / HUD** (top-right) — participant list, status, event log,
+  session clock. Rendered in HTML/CSS, updated from LiveKit room
+  events and DataChannel messages.
+- **ARTIFACTS** (bottom-right) — list of PDFs available for the
+  session; each entry is a download link hitting `/artifacts/...`.
+  Dynamic entries can be generated on-demand.
+
+**LiveKit integration:** client uses `livekit-client` UMD bundle
+pulled from npm once, checked into `vendor/`. Connects via the same
+wss URL we already have. Token is passed as `?t=<jwt>` in the URL
+(mint via `Fuller/artemis-tokens/mint.py` or a /mint endpoint later).
+
+**Caddy route:**
+
+```caddy
+handle /table/* {
+    uri strip_prefix /table
+    root * /home/claude/atlas-web/table
+    try_files {path} /index.html
+    file_server
+}
+```
+
+**Done when:**
+- Two players open `/table/<session>?t=<token>` in browsers
+- They see each other's audio levels, ARTEMIS's video, and can speak
+- ARTEMIS posts canned responses when a player stops speaking
+- All three cards render with correct data
+
+---
+
+## Phase C — PDF artifact service
+
+**Goal:** serve player handouts on-demand, generated from the campaign
+bible. Supports both static (pre-built) and dynamic (per-session) PDFs.
+
+**Scope:**
+
+```
+src/agi/primer/artemis/artifacts/
+├── __init__.py
+├── service.py        — small Flask app, one endpoint per handout
+├── templates/        — Jinja templates for dynamic PDFs
+└── static/           — CSS for PDF styling
+```
+
+**Endpoints:**
+
+| Path | Source | Type |
+|---|---|---|
+| `/artifacts/contract.pdf` | Handout 1 from `Beyond_the_Heliopause_Campaign_Guide.md` | Static (cached) |
+| `/artifacts/halyard-deck.pdf` | §9 ship chapter | Static |
+| `/artifacts/keeper-tightbeam.pdf` | Handout 2 | Static |
+| `/artifacts/unborn-petition.pdf` | Handout 3 | Static |
+| `/artifacts/bailey-diary.pdf` | Handout 4 | Static |
+| `/artifacts/pdc-discrepancy.pdf` | Handout 5 | Static |
+| `/artifacts/pregens.pdf` | Appendix E | Static |
+| `/artifacts/session-summary.pdf?session=X` | Session log + proof chain | Dynamic |
+
+**Generation:** pandoc on Atlas (already installed per
+`atlas_runner.py` memory). Service shells out to `pandoc <md> -o <pdf>
+--template=<tex>` on first request and caches results.
+
+**Systemd unit:** `atlas-artifacts.service` on port 8086.
+
+**Caddy route:**
+
+```caddy
+handle /artifacts/* {
+    reverse_proxy 127.0.0.1:8086
+}
+```
+
+**Done when:**
+- Every static handout renders as a PDF
+- Dynamic session-summary endpoint produces a PDF for a running session
+- Links from the ARTIFACTS card in Phase A open the PDFs in a new tab
+
+---
+
+## Phase B — 3D humanoid avatar (gated, next sprint)
+
+**Goal:** replace the Python-rendered HUD video track with a
+browser-rendered 3D humanoid. Female Max-Headroom-adjacent aesthetic —
+stylized, not photoreal. Lip-sync from phoneme stream.
+
+**Architecture pivot:**
+
+Current:
+```
+Piper (Atlas) → PIL render (Atlas) → video track → browser displays pixels
+```
+
+Phase B:
+```
+Piper (Atlas) → audio track + phoneme events via DataChannel
+                      ▼
+                   browser Three.js scene
+                      ├─ Ready Player Me humanoid model
+                      ├─ viseme blendshapes driven by phoneme events
+                      └─ renders locally at browser framerate
+```
+
+**Tech pick: Ready Player Me (RPM).**
+
+- Reason: has the right aesthetic (stylized, not photoreal); ships
+  with viseme blendshapes (jawOpen, mouthFunnel, mouthPucker, etc.)
+  that map 1:1 to Piper's IPA phonemes; loads via a URL we control;
+  Three.js integration is documented and maintained.
+- Alternatives considered: VRM/VRoid (anime-styled, less good for
+  sci-fi feel); custom glTF + manual rig (too much content work for
+  this project).
+
+**Phoneme → viseme mapping:** already have this in
+`artemis_avatar.py`'s `phoneme_to_viseme`. Extend from 4 shapes to
+the full RPM viseme set (15 blendshapes).
+
+**Data channel protocol:** ARTEMIS agent publishes
+`agi.rh.artemis.say` with `{text, proof_hash, timings[]}` where
+`timings[]` is a list of `{phoneme, start_ms, duration_ms}`. Browser
+maps each to a blendshape, interpolates at framerate.
+
+**Server-side work:**
+- Compute phoneme timings from Piper's output (currently uniform; can
+  be improved with forced alignment via gentle or whisper-alignments
+  if quality demands it)
+- Publish timings alongside audio
+
+**Browser-side work:**
+- Load Three.js + RPM loader
+- Render scene with lighting, background matching the table UI
+- Subscribe to DataChannel speech events
+- Drive blendshapes in the animation loop
+
+**Estimated scope:** 1-2 days of focused work. Not shipping tonight.
+
+**Done when:**
+- Browser renders a humanoid avatar in the AVATAR card (not the HUD
+  video track)
+- Mouth lip-syncs readably when ARTEMIS speaks
+- Head has subtle idle motion (breathing, micro-head-tilts)
+- No perceptible latency between audio and lip movement
+
+---
+
+## Phase D — ASR + real responses (next sprint)
+
+**Goal:** replace canned responses with actual reasoning. Whisper on
+Atlas listens to room audio, routes via NATS to Phase 2
+`ArtemisService`, Primer+vMOE generates a real reply, pipeline plays
+it through ARTEMIS's voice.
+
+**Scope:**
+- Add Whisper ASR to `avatar_hud.py`: subscribe to room audio,
+  stream through faster-whisper, publish finalized utterances on
+  `agi.rh.artemis.heard`.
+- Atlas `atlas-artemis.service` (already deployed per Phase 2) is the
+  other end of this pipe.
+- Replies from `agi.rh.artemis.say` feed into the TTS queue.
+
+**Done when:**
+- Addressing ARTEMIS by name produces a contextually-relevant reply
+  (not "Acknowledged")
+- DecisionProof chain grows with each turn
+- End-to-end latency ≤ 6 seconds (ASR + LLM + TTS)
+
+---
+
+## Phase E — ErisML game-scenario modeling (deferred)
+
+**Goal:** route game decisions through ErisML's Hohfeldian analysis so
+ARTEMIS reasons with formal ethics structure rather than free-form
+LLM output.
+
+**Out of scope for now.** Captured here because the user asked.
+Needs its own design doc once A-D land.
+
+---
+
+## Phase F — Camera / participant face detection (deferred)
+
+**Goal:** let ARTEMIS "see" players via OpenCV face detection on their
+subscribed video tracks, feed signals into the reasoning context
+("three players visible, imogen's face shows surprise").
+
+**Out of scope for now.** Low marginal value vs. ASR (which gives
+linguistic signal, much richer than face-detection boolean).
+
+---
+
+## Ordering
+
+| # | Phase | Effort | Blocks |
+|---|---|---|---|
+| 1 | 3.5 consolidate | 30 min | A |
+| 2 | A web UI | 1 h | deploy |
+| 3 | C artifacts | 30 min | deploy |
+| 4 | deploy both | 30 min | user eval |
+| 5 | B 3D avatar | 1-2 days | dedicated sprint |
+| 6 | D ASR + reasoning | 4 h | next session |
+| 7 | E ErisML | TBD | designs first |
+| 8 | F face detect | 3 h | low priority |
+
+Tonight: 1 → 2 → 3 → 4. B-F by appointment.

--- a/docs/ARTEMIS_SPRINT_PLAN.md
+++ b/docs/ARTEMIS_SPRINT_PLAN.md
@@ -1,0 +1,528 @@
+# ARTEMIS Multi-Sprint Plan
+
+> Consolidated plan across every feature discussed so far for ARTEMIS.
+> For your review before execution.
+
+**Date:** 2026-04-23
+**Status:** DRAFT — awaiting review
+
+This supersedes the phase-oriented [`ARTEMIS_AVATAR_ROADMAP.md`](ARTEMIS_AVATAR_ROADMAP.md)
+by reorganizing into discrete, shippable sprints with dependencies and
+honest effort estimates.
+
+---
+
+## Current state (checkpoint)
+
+**Already landed on `main`:**
+- Phase 1 — offline `handle_turn`, validator, DecisionProof chain (PR #85)
+- Phase 2 — NATS handler, systemd unit, 20-turn round-trip test (PR #86)
+- Phase 3 — LiveKit agent skeleton, JWT minting, scaffolding (PR #87)
+
+**Running on Atlas but not yet committed:**
+- v4 HUD avatar agent at `/home/claude/artemis_avatar.py` — icosahedron
+  wireframe HUD + Piper TTS (Amy) + canned responder + 960×720 @ 30 fps
+  with simulcast
+
+**Written in worktree `artemis/phase-3.5-avatar` but not committed / deployed:**
+- Phase 3.5 consolidation (avatar_hud.py → repo, systemd unit)
+- `docs/ARTEMIS_AVATAR_ROADMAP.md` (older planning doc)
+- Phase A `deploy/web/table/` — custom table UI (index.html, table.css,
+  table.js, vendor readme)
+- This sprint plan you are reading
+
+**Atlas infrastructure:**
+- LiveKit server (docker container, dev-mode keys)
+- Caddy route `/livekit/*` → `127.0.0.1:7880` (TLS via duckdns cert)
+- UDP 50000-50100 router-forwarded
+- Two test tokens (keeper + player) working end-to-end
+
+---
+
+## Design principles — kept across all sprints
+
+1. **Ship shippable slices.** Every sprint's output is usable at the table, not a half-built stepping stone.
+2. **Atlas-hosted by default.** No cloud dependencies unless explicitly justified.
+3. **Reuse the Phase 1/2 substrate.** The NATS subjects, validator, proof chain stay as they are.
+4. **Browser = thin client.** Heavy lifting stays on Atlas.
+5. **Roll-back friendly.** Each sprint is revertable without cascading into prior work.
+
+---
+
+## Sprint 0 — Consolidation (IN PROGRESS)
+
+**Goal:** land the running experiment into version control + give the
+table a real web UI + basic artifact downloads. Get everything off
+`/home/claude/` and onto `main`.
+
+**Effort:** ~2 hrs
+
+**Items:**
+
+- [x] **S0-1** Roadmap doc and sprint plan (this file) — done
+- [ ] **S0-2** Move `artemis_avatar.py` → `src/agi/primer/artemis/livekit_agent/avatar_hud.py`
+- [ ] **S0-3** `deploy/systemd/atlas-artemis-avatar.service`
+- [ ] **S0-4** Phase A table UI (`deploy/web/table/` — done in worktree)
+- [ ] **S0-5** Phase C PDF artifact service (`src/agi/primer/artemis/artifacts/`)
+- [ ] **S0-6** Caddy additions — `/table/*`, `/artifacts/*`
+- [ ] **S0-7** Deploy + verify end-to-end on Atlas
+- [ ] **S0-8** PR + CI + merge
+
+**Done when:**
+- Players open `https://atlas-sjsu.duckdns.org/table/<session>?t=<jwt>`
+- Three cards visible: avatar (HUD), info/HUD, artifacts
+- At least 3 static PDFs (contract, tightbeam, pregens) downloadable
+- ARTEMIS joins as 3rd participant with HUD + TTS
+- Unit tests green on CI, PR merged
+
+---
+
+## Sprint 1 — Real responsiveness (ASR → reasoning → speech)
+
+**Goal:** replace canned "Acknowledged" with actual LLM-generated
+replies. Wire Whisper ASR, NATS plumbing, and the Phase 2 Primer.
+
+**Effort:** ~1 day
+
+**Items:**
+
+- **S1-1** Subscribe to remote-participant audio tracks in the avatar
+  agent. Stream each into `faster-whisper` (already installed on
+  Atlas GPU).
+- **S1-2** Publish finalized utterances to `agi.rh.artemis.heard` with
+  the TurnRequest schema.
+- **S1-3** Verify `atlas-artemis.service` (Phase 2 handler, already
+  on main) picks them up and routes through vMOE.
+- **S1-4** Consume `agi.rh.artemis.say` in the avatar agent → queue
+  for TTS → played + logged.
+- **S1-5** **Keeper approval gate UI** in the browser (right-side
+  card): sidebar shows pending reply with ✓/✗. Approved replies
+  flow through; rejected are dropped + logged.
+- **S1-6** Campaign bible chunked and indexed into Atlas RAG so Primer
+  has game context.
+- **S1-7** Set `NRP_LLM_TOKEN` env on Atlas for real LLM calls via ellm.
+
+**Depends on:** S0 (needs UI card to put approval gate in)
+
+**Done when:**
+- Ask ARTEMIS a question → relevant reply within ~6s end-to-end
+- Keeper sees approval prompt, can accept/reject
+- DecisionProof chain grows with each turn
+- Latency p50 < 5s, p95 < 10s
+
+---
+
+## Sprint 2 — LiveKit production polish
+
+**Goal:** fix the media-quality rough edges so this is usable in a
+real 4-hour session.
+
+**Effort:** ~1 day
+
+**Items:**
+
+- **S2-1** **Noise cancellation** — integrate Krisp `TrackProcessor`
+  (LiveKit plugin). Auto-applied to inbound participant audio.
+- **S2-2** **Push-to-talk** — toggle in avatar card, `M` key binding.
+  Default off for player mics, on-demand.
+- **S2-3** **Live transcription card** — show a rolling text of what
+  ARTEMIS said (already have text via TTS path) + optional ASR
+  transcriptions of players.
+- **S2-4** **X-card button** — top-right of every card. On click:
+  publishes `agi.rh.artemis.silence` via NATS (kill-switch, already
+  supported by Phase 2 handler). 5-min cooldown default.
+- **S2-5** **Voice quality upgrade** — try Coqui XTTS for a
+  higher-fidelity voice alternative; keep Piper as fallback. Env-var
+  selectable.
+- **S2-6** Reconnect handling — graceful UX when a player's WiFi
+  blips.
+
+**Depends on:** S0
+
+**Done when:**
+- Full 60-min test with 3 humans + ARTEMIS, no quality complaints
+- X-card triggers immediate ARTEMIS silence
+- Voice sounds noticeably better than Piper Amy medium
+
+---
+
+## Sprint 3 — 3D humanoid avatar (Phase B proper)
+
+**Goal:** replace the Python-rendered HUD with a browser-rendered
+female humanoid 3D avatar. Viseme lip-sync, idle animations.
+
+**Effort:** ~2 days
+
+**Stack pick (for review):**
+- **Three.js** for rendering
+- **Ready Player Me (RPM)** for the avatar model (stylized, has
+  viseme blendshapes built in, URL-loadable, free tier)
+- **Piper forced-alignment** for phoneme timing (or gentle-aligner
+  if better precision needed)
+- **LiveKit DataChannel** for audio timing cues
+
+**Items:**
+
+- **S3-1** Generate an RPM avatar (user picks via their web UI).
+  Pin the URL. Design note: avoid photorealism — stylized matches
+  ARTEMIS.
+- **S3-2** Integrate Three.js into `table.js` — scene, camera,
+  lighting, RPM model loader.
+- **S3-3** Viseme blendshape driver — map Piper IPA → RPM blendshape
+  names. 15 shapes total.
+- **S3-4** **Phoneme timing publisher** on Atlas — extend Piper TTS
+  pipeline to emit `{phoneme, start_ms, dur_ms}` timings via
+  DataChannel alongside audio.
+- **S3-5** Avatar card switches from `<video>` track to Three.js
+  canvas.
+- **S3-6** Idle animations — subtle head tilt, blinking, breathing
+  (linear combination of small blendshapes over time).
+- **S3-7** Expression cues — slight eyebrow lift when "listening,"
+  neutral when "speaking." Drive from NATS events.
+- **S3-8** Retire the HUD video track publisher (or relegate to a
+  backup-mode env var).
+
+**Depends on:** S0, S1 (for real speech events + timings)
+
+**Done when:**
+- Browser renders humanoid avatar, mouth moves in readable sync with
+  TTS
+- Latency between audio and lip-movement < 100ms
+- 60fps rendering on target hardware (Atlas → desktop browsers)
+- Old HUD video track removed
+
+---
+
+## Sprint 4 — Game-table features
+
+**Goal:** actual TTRPG session companion features.
+
+**Effort:** ~1 day
+
+**Items:**
+
+- **S4-1** **Dice roller** — UI control in the avatar card; supports
+  d4/d6/d8/d10/d12/d20/d100 + modifiers. Each roll broadcast via
+  DataChannel, logged in INFO card, visible to all players.
+- **S4-2** **Shared roll log** — persistent across the session,
+  exportable to session replay.
+- **S4-3** **Handout push** — Keeper clicks a handout in ARTIFACTS,
+  triggers all players' browsers to open it.
+- **S4-4** **Scene state** — room.metadata field `"scene": "..."`.
+  Changes broadcast to all. ARTEMIS's system prompt updates when
+  scene changes (new scene → extra context block in handle_turn).
+- **S4-5** **Character sheets** — live-updatable SAN, HP, Luck, MP
+  per PC. Stored in room.metadata, rendered in a collapsible card
+  under ARTIFACTS.
+- **S4-6** **Keeper panel** — sidebar only Keeper can see. Scene
+  controls, approval queue, kill-switch, quick-silence-ARTEMIS.
+
+**Depends on:** S0
+
+**Done when:**
+- Full session playable without external tools (dice, sheets,
+  handouts all in-app)
+- Scene transitions make ARTEMIS context-aware
+- Keeper has an ergonomic control surface
+
+---
+
+## Sprint 5 — Atmosphere + experience
+
+**Goal:** production value — ambient sound, keyboard shortcuts,
+accessibility polish.
+
+**Effort:** ~0.5 days
+
+**Items:**
+
+- **S5-1** **Ambient soundscape per scene** — a second low-volume
+  audio track ARTEMIS publishes that loops the scene's ambience
+  (ship hum, vault silence, Mi-go installation buzz). Swaps on
+  scene change. Pre-made ~5 min WAVs per scene.
+- **S5-2** **Keyboard shortcuts** — M mute, Space PTT, X x-card,
+  D dice, ESC leave.
+- **S5-3** **Accessibility** — ARIA labels, keyboard nav, sufficient
+  contrast in amber-on-black (audit WCAG AA).
+- **S5-4** **Mobile-friendly** layout breakpoints (cards stack on
+  narrow screens).
+
+**Depends on:** S4 (scene state)
+
+**Done when:**
+- Every interaction keyboard-accessible
+- Mobile browsers render usably (even if not ideal)
+- Ambient sound fades between scenes
+
+---
+
+## Sprint 6 — ErisML integration
+
+**Goal:** route every ARTEMIS reply through ErisML's Hohfeldian
+moral-vector analysis before it's posted. The validator's current
+`erisml_check` is a Phase-1 stub — this sprint makes it real.
+
+**Effort:** ~1 day
+
+**Items:**
+
+- **S6-1** Import `erisml-lib` into the artemis validator.
+- **S6-2** **Scenario encoder** — convert a proposed ARTEMIS reply +
+  current game state into the rank-6 Coo6 tensor that ErisML expects.
+- **S6-3** Run the tensor through ErisML's Python reference (bit-exact
+  with the eventual EPU hardware path).
+- **S6-4** Reject replies whose invariant-vector indicates moral
+  concern beyond a configurable threshold; DecisionProof records
+  the full vector.
+- **S6-5** Keeper-visible "why rejected" explainer using ErisML's
+  Hohfeldian correlative trace.
+- **S6-6** Extended tests: 50 hand-crafted scenarios with expected
+  verdicts.
+
+**Depends on:** S1 (need real replies to reason about)
+
+**Done when:**
+- Every posted reply has ErisML verdict in its DecisionProof
+- Borderline-unethical canned scenarios get correctly rejected
+- The explainer surface is useful (not just "rejected because bad")
+
+---
+
+## Sprint 7 — Recording + ops
+
+**Goal:** session archival + observability.
+
+**Effort:** ~1 day
+
+**Items:**
+
+- **S7-1** **LiveKit Egress** — server-side composite MP4 recording
+  of each session. Stored under `/archive/artemis/sessions/<id>/`.
+- **S7-2** **Session replay export** — single ZIP bundle: MP4 +
+  proof-chain + session log + handout PDFs. Downloadable from the
+  ARTIFACTS card after session ends.
+- **S7-3** **Dashboard tile** in `schematic.html` — ARTEMIS panel
+  showing: active sessions, turn count, validator reject rate,
+  p50/p95 turn latency.
+- **S7-4** **Prometheus metrics** exported from atlas-artemis.service
+  for historical graphing.
+- **S7-5** **Backup inclusion** — session logs + proofs in
+  atlas-backup.timer.
+
+**Depends on:** S0
+
+**Done when:**
+- Each completed session is archived automatically
+- Dashboard shows live metrics
+- Keeper can hand a player a ZIP of "the whole session I just played in"
+
+---
+
+## Sprint 8 — Camera / face detection
+
+**Goal:** let ARTEMIS visually "notice" participants.
+
+**Effort:** ~0.5 days
+
+**Items:**
+
+- **S8-1** Subscribe to remote participants' video tracks in the
+  avatar agent.
+- **S8-2** Sample 1fps, run OpenCV haar-cascade face detection (or
+  MediaPipe face landmarker).
+- **S8-3** Publish presence events (`{speaker: x, face_visible: bool,
+  bbox}`) on NATS `agi.rh.artemis.sees.*`.
+- **S8-4** Feed into reasoning context — available to Primer as
+  an extra context block.
+
+**Depends on:** S1
+
+**Low priority — text + speech signal is much richer than "face visible
+boolean." Listed for completeness because user asked.**
+
+**Done when:**
+- Atlas logs face-visible events per frame
+- ARTEMIS's context includes "3 of 4 players visible on camera"
+
+---
+
+## Sprint 9 — EPU FPGA validator swap
+
+**Goal:** replace the ErisML Python reference in the validator with
+the FPGA-hardware path. Same bit-exact math, different backend.
+
+**Effort:** ~0.5 days (once unblocked)
+
+**Blocked on:** external — the NRP Coder workspace auto-restart issue
+preventing the Phase 3 `v++ link` for the TPU kernel. Once that ships,
+Phase 5 Integration service is the call target.
+
+**Items:**
+
+- **S9-1** Swap validator backend: HTTP call to the EPU Phase 5
+  Docker-compose service.
+- **S9-2** Bit-exact smoke test: 10k scenarios, Python ref vs FPGA
+  must agree.
+- **S9-3** DecisionProof chains into EPU's SHA chain — both chains
+  cross-verifiable.
+- **S9-4** Metrics: FPGA latency vs Python reference.
+
+**Done when:**
+- Every reply's ErisML check runs on real U55C hardware
+- SHA chains verify end-to-end
+- Latency improvement measurable (expected µs vs ms)
+
+---
+
+## Sprint 10 — Atlas diagnostics in-table (widgets from `schematic.html`)
+
+**Goal:** surface interesting panels from the existing Atlas dashboard
+inside the game table UI so ARTEMIS feels like it's showing you its
+actual mind. Diegetic framing: these are "the handheld's diagnostic
+telemetry" that the in-fiction character would expose.
+
+**Effort:** ~1 day
+
+**Which panels to pull (ranked by in-fiction fit + info density):**
+
+| Dashboard panel | In-fiction framing | Card placement |
+|---|---|---|
+| NATS Live (message stream) | "neural pathway traffic" | NEW: DIAGNOSTICS card |
+| Primer health / vMOE expert status | "active cognitive cores" | DIAGNOSTICS |
+| GPU temperature + utilization | "thermal / processing load" | DIAGNOSTICS |
+| Memory tier L0/L1/L2/L3/L4 stats | "episodic recall depth" | DIAGNOSTICS |
+| NRP burst jobs table | "offloaded computation" | DIAGNOSTICS |
+| Recent DecisionProof rejects | "ethical veto stream" | INFO card (existing) |
+| ARC scientist progress | (too meta, skip) | — |
+
+**Items:**
+
+- **S10-1** Add a **DIAGNOSTICS card** (fourth card in the right-column
+  stack, collapsible). Default collapsed; Keeper can expand.
+- **S10-2** Each widget is a small Svelte-less HTML component that
+  polls an existing `/api/*` endpoint on Atlas (already served by
+  `atlas-telemetry.service`):
+  - `/api/nats/live?subject=agi.rh.artemis.*` — filter to only
+    ARTEMIS-relevant subjects
+  - `/api/primer/health` — vMOE expert summary
+  - `/api/gpu/status` — temps + utilization
+  - `/api/memory/tiers` — L0-L4 cardinality
+  - `/api/burst/jobs` — NRP burst list
+- **S10-3** Styling — amber-on-black to match the table UI. Tiny
+  sparklines where appropriate (one line of SVG each).
+- **S10-4** Keeper-only toggle — hide Diagnostics from players if
+  distracting. Store in `room.metadata`.
+- **S10-5** **Redacted mode** — when a player is viewing, some panels
+  (e.g. "ethical veto stream") show redacted text so we don't leak
+  what ARTEMIS suppressed. Keeper view = full.
+- **S10-6** **Caddy route** already exposes `/api/*` → 8085, so CORS
+  is a non-issue as long as the table page is on the same origin
+  (`atlas-sjsu.duckdns.org`).
+
+**Depends on:** S0 (needs the card layout), S4 (scene state for
+Keeper-only toggle), S1 (for the decision-proof stream to have content)
+
+**Done when:**
+- DIAGNOSTICS card renders with at least 3 live widgets
+- Widget data updates at 1-2 Hz without impacting the main
+  game-session performance
+- Keeper can toggle visibility per-session
+- Redacted mode works for player views
+
+**Why this is cool:**
+- The Atlas dashboard already exists; this is mostly glue.
+- It makes ARTEMIS feel *real* in a way that pre-rendered animations
+  can't match — you're literally watching its thought process during
+  the session.
+- Post-session, an archived diagnostic feed becomes part of the session
+  replay bundle (S7).
+
+---
+
+## Sprint 11 — Security + consent
+
+**Goal:** real-session safety posture beyond dev-mode.
+
+**Effort:** ~0.5 days
+
+**Items:**
+
+- **S11-1** **E2EE** — LiveKit end-to-end encryption with shared
+  key per session. Tokens carry the key. Media not decrypted by
+  SFU.
+- **S11-2** Rotate LiveKit API key/secret off `devkey`/`secret` —
+  proper secrets in Atlas `.env` files.
+- **S11-3** **Recording consent opt-in** — per-participant banner
+  + checkbox before joining a recorded session.
+- **S11-4** **Token mint service** with user:read:token-style scope
+  so tokens don't all pre-exist as files in `Fuller/artemis-tokens/`.
+
+**Depends on:** S7 (recording exists to consent to)
+
+**Done when:**
+- No default/weak credentials in production
+- Encryption verified via LiveKit UI indicator
+- Consent banner blocks join until acknowledged
+
+---
+
+## Sprint order (dependency-aware)
+
+```
+S0 (current) ──┬── S1 ──┬── S3 ─── S6
+               │        │    │
+               ├── S2   │    │
+               ├── S4   │    │
+               ├── S5 (after S4)
+               ├── S7 ──┬── S11
+               │        │
+               ├── S8 ──┤
+               ├── S9 (blocked externally)
+               └── S10 (after S0, S1, S4)
+```
+
+Critical path to a shippable tabletop: **S0 → S1 → S3 → S4 → S7**
+(~5-6 focused days of work). S2, S5, S6, S10 can interleave. S8/S9/S11
+are parallel-later.
+
+---
+
+## Effort total
+
+| Sprint | Effort | Value | Priority |
+|---|---|---|---|
+| S0 consolidation | 2 hrs | foundation | NOW |
+| S1 real responsiveness | 1 day | must-have | next |
+| S2 LiveKit polish | 1 day | high | next |
+| S3 3D avatar | 2 days | high | after S1 |
+| S4 game features | 1 day | high | after S0 |
+| S5 atmosphere | 0.5 day | medium | after S4 |
+| S6 ErisML integration | 1 day | distinguishing | after S1 |
+| S7 recording + ops | 1 day | high | after S0 |
+| S8 face detection | 0.5 day | low | after S1 |
+| S9 FPGA swap | 0.5 day | distinguishing | blocked |
+| S10 Atlas diagnostics in-table | 1 day | cool + meta | after S0+S4 |
+| S11 security + consent | 0.5 day | required for prod | after S7 |
+
+**Total:** ~11 days of focused engineering, spread across as many
+sessions as the calendar allows.
+
+---
+
+## Questions for you before we start
+
+1. **Do you want the full sprint plan landed in this PR (S0 +
+   this doc), or split — land S0 now, add this plan in a follow-up?**
+2. **Any sprint you want to reorder?** E.g., if the 3D avatar (S3) is
+   urgent-cool and you'd rather have that before ASR (S1), that's a
+   valid tradeoff but means ARTEMIS still gives canned replies for
+   longer.
+3. **Any sprint you want to strike entirely?** E.g., S8 face-detection
+   is low-leverage; I'd deprioritize or drop it.
+4. **Stack picks to review:**
+   - Ready Player Me vs VRM/VRoid for 3D avatar?
+   - Coqui XTTS vs higher-quality Piper voices for voice upgrade?
+   - `livekit-egress` for recording — OK to add as a sibling container?
+
+Mark up this file directly in review, or reply with a consolidated
+"S0 go, S1 first, swap S3 and S4" and I'll update and execute.

--- a/src/agi/primer/artemis/livekit_agent/avatar_hud.py
+++ b/src/agi/primer/artemis/livekit_agent/avatar_hud.py
@@ -1,0 +1,622 @@
+#!/usr/bin/env python3
+"""ARTEMIS avatar v4 — sci-fi HUD instead of cartoon face.
+
+Replaces the 2D cartoon face with a projection-rendered rotating
+wireframe icosahedron at center, radial audio-reactive spectrum bars,
+a scrolling event log, and a low-amplitude waveform — amber-on-black
+terminal aesthetic (Expanse / Blade Runner UI).
+
+This matches the in-fiction concept of "the handheld's screen" far
+better than a drawn face, and scales up in visual quality without
+requiring 3D assets.
+
+Still 2D-rasterized → video track. True 3D would need OpenGL
+(moderngl / Panda3D) — separate sprint if we want polygonal lighting.
+
+TTS (Piper) + phoneme-derived speech intensity are carried over. No
+face = no lip-sync, but the visualization pulses with audio so it
+reads as "speaking" clearly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import collections
+import json
+import logging
+import math
+import os
+import queue
+import random
+import signal
+import sys
+import threading
+import time
+
+import numpy as np
+from livekit import api, rtc
+from PIL import Image, ImageDraw, ImageFont
+
+log = logging.getLogger("artemis.avatar")
+
+# Video geometry — 960×720 gives the codec enough pixels per element
+# to keep elements readable after compression. Dropping from 20→30 fps
+# makes motion smoother and lets the codec spend bits on the right
+# frames instead of duplicates.
+W, H = 960, 720
+FPS = 30
+
+AUDIO_SR = 22050
+AUDIO_CHANNELS = 1
+AUDIO_FRAME_MS = 20
+AUDIO_SAMPLES_PER_FRAME = AUDIO_SR * AUDIO_FRAME_MS // 1000
+
+PIPER_VOICE = os.environ.get(
+    "ARTEMIS_VOICE", "/home/claude/piper-voices/en_US-amy-medium.onnx"
+)
+
+CANNED_REPLIES = [
+    "Acknowledged.",
+    "Noted.",
+    "Scanning.",
+    "The readings are nominal.",
+    "Processing.",
+    "Stand by.",
+    "One moment.",
+    "Logged.",
+    "The handheld is listening.",
+]
+
+# ─────────────────────────────────────────────────────────────────
+# Palette — amber-on-black terminal
+# ─────────────────────────────────────────────────────────────────
+
+BG = (6, 6, 10)
+AMBER = (255, 176, 48)
+AMBER_DIM = (120, 72, 10)
+AMBER_DEEP = (60, 36, 4)
+CYAN = (80, 220, 240)
+CYAN_DIM = (30, 110, 130)
+WHITE_DIM = (180, 180, 200)
+GRID = (24, 24, 34)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Shared state
+# ─────────────────────────────────────────────────────────────────
+
+
+class AvatarState:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.active_speakers: list[str] = []
+        self.participants: list[str] = []
+        self.speaking: bool = False
+        self.amp: float = 0.0  # 0..1 — ARTEMIS's own audio amplitude
+        # Ring buffer of events for the scrolling log.
+        self.events: collections.deque = collections.deque(maxlen=6)
+        # Spectrum energy per band (16 bands, 0..1 each), driven by FFT.
+        self.spectrum: list[float] = [0.0] * 16
+
+    def set_active(self, xs: list[str]) -> None:
+        with self._lock:
+            self.active_speakers = list(xs)
+
+    def set_participants(self, xs: list[str]) -> None:
+        with self._lock:
+            self.participants = list(xs)
+
+    def set_speaking(self, speaking: bool, amp: float) -> None:
+        with self._lock:
+            self.speaking = speaking
+            self.amp = max(0.0, min(1.0, amp))
+
+    def set_spectrum(self, bands: list[float]) -> None:
+        with self._lock:
+            self.spectrum = list(bands)
+
+    def log_event(self, line: str) -> None:
+        with self._lock:
+            ts = time.strftime("%H:%M:%S", time.localtime())
+            self.events.append(f"{ts}  {line}")
+
+    def snap(self):
+        with self._lock:
+            return (
+                list(self.active_speakers),
+                list(self.participants),
+                self.speaking,
+                self.amp,
+                list(self.spectrum),
+                list(self.events),
+            )
+
+
+STATE = AvatarState()
+
+
+# ─────────────────────────────────────────────────────────────────
+# Icosahedron geometry
+# ─────────────────────────────────────────────────────────────────
+
+_phi = (1 + math.sqrt(5)) / 2
+VERTS_3D = [
+    (-1, _phi, 0),
+    (1, _phi, 0),
+    (-1, -_phi, 0),
+    (1, -_phi, 0),
+    (0, -1, _phi),
+    (0, 1, _phi),
+    (0, -1, -_phi),
+    (0, 1, -_phi),
+    (_phi, 0, -1),
+    (_phi, 0, 1),
+    (-_phi, 0, -1),
+    (-_phi, 0, 1),
+]
+EDGES = [
+    (0, 1),
+    (0, 5),
+    (0, 7),
+    (0, 10),
+    (0, 11),
+    (1, 5),
+    (1, 7),
+    (1, 8),
+    (1, 9),
+    (2, 3),
+    (2, 4),
+    (2, 6),
+    (2, 10),
+    (2, 11),
+    (3, 4),
+    (3, 6),
+    (3, 8),
+    (3, 9),
+    (4, 5),
+    (4, 9),
+    (4, 11),
+    (5, 9),
+    (5, 11),
+    (6, 7),
+    (6, 8),
+    (6, 10),
+    (7, 8),
+    (7, 10),
+    (8, 9),
+    (10, 11),
+]
+
+
+def project(v, rx: float, ry: float, rz: float, scale: float, cx: int, cy: int):
+    x, y, z = v
+    # Rotate Y
+    cy_, sy_ = math.cos(ry), math.sin(ry)
+    x, z = x * cy_ + z * sy_, -x * sy_ + z * cy_
+    # Rotate X
+    cx_, sx_ = math.cos(rx), math.sin(rx)
+    y, z = y * cx_ - z * sx_, y * sx_ + z * cx_
+    # Rotate Z
+    cz_, sz_ = math.cos(rz), math.sin(rz)
+    x, y = x * cz_ - y * sz_, x * sz_ + y * cz_
+    # Perspective
+    f = scale / (z + 4)
+    return (cx + x * f, cy + y * f, z)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Rendering
+# ─────────────────────────────────────────────────────────────────
+
+
+def _find_font(size: int) -> ImageFont.ImageFont:
+    for path in (
+        "/usr/share/fonts/truetype/dejavu/DejaVuSansMono-Bold.ttf",
+        "/usr/share/fonts/truetype/liberation/LiberationMono-Bold.ttf",
+    ):
+        if os.path.exists(path):
+            return ImageFont.truetype(path, size)
+    return ImageFont.load_default()
+
+
+_FONT_H1 = _find_font(28)
+_FONT_H2 = _find_font(16)
+_FONT_BODY = _find_font(12)
+_FONT_TINY = _find_font(10)
+
+
+def _draw_grid(draw: ImageDraw.ImageDraw) -> None:
+    # Sparse grid — 96 px intervals only. Fine-grain grid was destroying
+    # video-codec efficiency (every pixel different per frame = codec
+    # gives up and rasterizes aggressively).
+    for x in range(0, W, 96):
+        draw.line([(x, 0), (x, H)], fill=GRID, width=1)
+    for y in range(0, H, 96):
+        draw.line([(0, y), (W, y)], fill=GRID, width=1)
+
+
+def _fmt_speaker(ident: str) -> str:
+    return ident.split(":", 1)[-1].upper() if ":" in ident else ident.upper()
+
+
+def render_frame(t: float) -> np.ndarray:
+    actives, parts, speaking, amp, spectrum, events = STATE.snap()
+
+    img = Image.new("RGB", (W, H), BG)
+    draw = ImageDraw.Draw(img)
+
+    _draw_grid(draw)
+
+    cx, cy = W // 2, H // 2
+
+    # ── Outer ring (radial spectrum bars) ────────────────────────
+    n_bars = 32
+    base_r = 170
+    for i in range(n_bars):
+        angle = 2 * math.pi * i / n_bars - math.pi / 2
+        band = spectrum[i % len(spectrum)]
+        length = 14 + band * 56 + (6 if speaking else 0) * math.sin(t * 3 + i * 0.3)
+        x1 = cx + math.cos(angle) * base_r
+        y1 = cy + math.sin(angle) * base_r
+        x2 = cx + math.cos(angle) * (base_r + length)
+        y2 = cy + math.sin(angle) * (base_r + length)
+        color = AMBER if (speaking or band > 0.15) else AMBER_DIM
+        draw.line([(x1, y1), (x2, y2)], fill=color, width=3)
+
+    # Faint concentric guide rings
+    for r in (base_r, base_r + 68):
+        bbox = (cx - r, cy - r, cx + r, cy + r)
+        draw.ellipse(bbox, outline=AMBER_DEEP, width=1)
+
+    # ── Rotating wireframe icosahedron ───────────────────────────
+    rx = t * 0.35
+    ry = t * 0.55
+    rz = math.sin(t * 0.2) * 0.15
+    scale = 70 + (amp * 20)
+    projected = [project(v, rx, ry, rz, scale, cx, cy) for v in VERTS_3D]
+    # Draw edges; stroke color depends on back/front
+    for a, b in EDGES:
+        p1 = projected[a]
+        p2 = projected[b]
+        avg_z = (p1[2] + p2[2]) / 2
+        # Back edges faded
+        t_front = (avg_z + 2.5) / 5.0
+        t_front = max(0.0, min(1.0, t_front))
+        c = tuple(
+            int(AMBER[i] * t_front + AMBER_DEEP[i] * (1 - t_front)) for i in range(3)
+        )
+        width = 3 if t_front > 0.5 else 1
+        draw.line([(p1[0], p1[1]), (p2[0], p2[1])], fill=c, width=width)
+
+    # Central glow dot — brighter when speaking
+    glow_r = 8 + int(amp * 10)
+    glow_color = CYAN if speaking else CYAN_DIM
+    draw.ellipse((cx - glow_r, cy - glow_r, cx + glow_r, cy + glow_r), fill=glow_color)
+
+    # ── HUD: top-left block ─────────────────────────────────────
+    draw.text((20, 18), "ARTEMIS", fill=AMBER, font=_FONT_H1)
+    draw.text((20, 52), "v0.3 · HANDHELD UI", fill=AMBER_DIM, font=_FONT_BODY)
+
+    # Status line
+    if speaking:
+        status = "> SPEAKING"
+        status_col = CYAN
+    elif actives:
+        others = [a for a in actives if a != "artemis"]
+        status = f"< HEARING {_fmt_speaker(others[0])}" if others else "> LISTENING"
+        status_col = AMBER
+    else:
+        status = "> LISTENING"
+        status_col = AMBER_DIM
+    draw.text((20, 76), status, fill=status_col, font=_FONT_H2)
+
+    # Top-right: timestamp + uptime
+    wall_time = time.strftime("%H:%M:%S UTC", time.gmtime())
+    draw.text((W - 180, 18), wall_time, fill=AMBER_DIM, font=_FONT_BODY)
+    draw.text((W - 180, 34), f"T+{int(t):>4}s", fill=AMBER_DIM, font=_FONT_BODY)
+    draw.text(
+        (W - 180, 50), f"PARTICIPANTS {len(parts):>2}", fill=AMBER_DIM, font=_FONT_BODY
+    )
+
+    # ── Participant list (right edge) ───────────────────────────
+    by = 110
+    for pid in parts[:6]:
+        color = CYAN if pid in actives else AMBER_DIM
+        prefix = ">" if pid == "artemis" else "·"
+        draw.text((W - 180, by), f"{prefix} {pid}", fill=color, font=_FONT_BODY)
+        by += 16
+
+    # ── Event log (bottom-left) ──────────────────────────────────
+    log_y = H - 115
+    draw.text((20, log_y), "EVENT LOG", fill=AMBER_DIM, font=_FONT_BODY)
+    for i, line in enumerate(list(events)[-6:]):
+        draw.text(
+            (20, log_y + 16 + i * 13),
+            line,
+            fill=AMBER_DIM if i < len(events) - 1 else AMBER,
+            font=_FONT_TINY,
+        )
+
+    # Scanlines intentionally removed. Per-3px horizontal noise was
+    # catastrophic for H.264/VP8 rate-distortion — every line differed
+    # from its neighbor so the codec couldn't exploit spatial
+    # redundancy, producing severe rasterization artifacts at the
+    # default publish bitrate.
+
+    return np.asarray(img, dtype=np.uint8)
+
+
+# ─────────────────────────────────────────────────────────────────
+# TTS + audio pipeline
+# ─────────────────────────────────────────────────────────────────
+
+
+text_queue: queue.Queue = queue.Queue()
+audio_queue: queue.Queue = queue.Queue()
+
+
+def _tts_worker() -> None:
+    log.info("loading piper voice: %s", PIPER_VOICE)
+    from piper import PiperVoice
+
+    voice = PiperVoice.load(PIPER_VOICE)
+    log.info("piper voice loaded (sr=%s)", voice.config.sample_rate)
+    while True:
+        text = text_queue.get()
+        if text is None:
+            return
+        try:
+            log.info("synthesizing: %s", text[:80])
+            all_pcm: list[np.ndarray] = []
+            for chunk in voice.synthesize(text):
+                pcm = np.frombuffer(chunk.audio_int16_bytes, dtype=np.int16)
+                all_pcm.append(pcm)
+            pcm = np.concatenate(all_pcm) if all_pcm else np.zeros(0, dtype=np.int16)
+            if voice.config.sample_rate != AUDIO_SR:
+                src_sr = voice.config.sample_rate
+                xs = np.arange(0, len(pcm), src_sr / AUDIO_SR)
+                pcm = np.interp(xs, np.arange(len(pcm)), pcm.astype(np.float32)).astype(
+                    np.int16
+                )
+            audio_queue.put(pcm)
+            STATE.log_event(f"SAY {text[:40]}")
+        except Exception as e:  # noqa: BLE001
+            log.exception("TTS error: %s", e)
+
+
+def _compute_spectrum(chunk: np.ndarray, n_bands: int = 16) -> list[float]:
+    """Cheap FFT-derived spectrum. Returns n_bands values in [0, 1]."""
+    if len(chunk) == 0:
+        return [0.0] * n_bands
+    x = chunk.astype(np.float32) / 32768.0
+    # Window to reduce spectral leakage
+    window = np.hanning(len(x))
+    spectrum = np.abs(np.fft.rfft(x * window))
+    # Bin into n_bands bands (log-spaced would be better; uniform for simplicity)
+    if len(spectrum) < n_bands:
+        bands = list(spectrum / (spectrum.max() + 1e-9))
+        return bands + [0.0] * (n_bands - len(bands))
+    step = len(spectrum) // n_bands
+    bands = [float(spectrum[i * step : (i + 1) * step].mean()) for i in range(n_bands)]
+    m = max(bands) if bands else 1.0
+    return [min(1.0, b / (m + 1e-9)) for b in bands]
+
+
+async def _audio_publisher(source: rtc.AudioSource, running: asyncio.Event) -> None:
+    silence = np.zeros(AUDIO_SAMPLES_PER_FRAME, dtype=np.int16)
+    frame_dt = AUDIO_FRAME_MS / 1000.0
+    next_t = time.monotonic()
+
+    pending: np.ndarray | None = None
+    offset = 0
+    while not running.is_set():
+        if pending is None:
+            try:
+                pending = audio_queue.get_nowait()
+                offset = 0
+            except queue.Empty:
+                pending = None
+
+        if pending is not None and offset < len(pending):
+            chunk = pending[offset : offset + AUDIO_SAMPLES_PER_FRAME]
+            offset += AUDIO_SAMPLES_PER_FRAME
+            if len(chunk) < AUDIO_SAMPLES_PER_FRAME:
+                chunk = np.concatenate(
+                    [chunk, silence[: AUDIO_SAMPLES_PER_FRAME - len(chunk)]]
+                )
+            rms = float(np.sqrt(np.mean(chunk.astype(np.float32) ** 2)))
+            STATE.set_speaking(True, min(1.0, rms / 4000.0))
+            STATE.set_spectrum(_compute_spectrum(chunk))
+            frame = rtc.AudioFrame(
+                chunk.tobytes(), AUDIO_SR, AUDIO_CHANNELS, AUDIO_SAMPLES_PER_FRAME
+            )
+            await source.capture_frame(frame)
+            if offset >= len(pending):
+                pending = None
+                STATE.set_speaking(False, 0.0)
+        else:
+            STATE.set_speaking(False, 0.0)
+            # Ambient spectrum decay
+            cur = STATE.snap()[4]
+            STATE.set_spectrum([max(0.0, v * 0.9) for v in cur])
+            frame = rtc.AudioFrame(
+                silence.tobytes(), AUDIO_SR, AUDIO_CHANNELS, AUDIO_SAMPLES_PER_FRAME
+            )
+            await source.capture_frame(frame)
+
+        next_t += frame_dt
+        sleep_for = next_t - time.monotonic()
+        if sleep_for > 0:
+            await asyncio.sleep(sleep_for)
+        else:
+            next_t = time.monotonic()
+
+
+async def _video_publisher(source: rtc.VideoSource, running: asyncio.Event) -> None:
+    frame_idx = 0
+    frame_dt = 1.0 / FPS
+    next_t = time.monotonic()
+    while not running.is_set():
+        sim_t = frame_idx / FPS
+        rgb = render_frame(sim_t)
+        rgba = np.concatenate(
+            [rgb, np.full(rgb.shape[:2] + (1,), 255, dtype=np.uint8)], axis=2
+        )
+        frame = rtc.VideoFrame(W, H, rtc.VideoBufferType.RGBA, rgba.tobytes())
+        source.capture_frame(frame)
+        frame_idx += 1
+        next_t += frame_dt
+        sleep_for = next_t - time.monotonic()
+        if sleep_for > 0:
+            await asyncio.sleep(sleep_for)
+        else:
+            next_t = time.monotonic()
+
+
+def refresh_participants(room: rtc.Room) -> None:
+    parts = [room.local_participant.identity]
+    parts.extend(p.identity for p in room.remote_participants.values())
+    STATE.set_participants(parts)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Responder (canned replies on user-finishes-speaking)
+# ─────────────────────────────────────────────────────────────────
+
+
+class Responder:
+    def __init__(self, min_gap_s: float = 4.0) -> None:
+        self.last_active: list[str] = []
+        self.last_reply_t: float = 0.0
+        self.min_gap_s = min_gap_s
+
+    def update(self, active: list[str]) -> None:
+        others_before = [a for a in self.last_active if a != "artemis"]
+        others_now = [a for a in active if a != "artemis"]
+        transitioned_to_idle = bool(others_before) and not others_now
+        now = time.time()
+        if transitioned_to_idle and (now - self.last_reply_t) > self.min_gap_s:
+            reply = random.choice(CANNED_REPLIES)
+            text_queue.put(reply)
+            self.last_reply_t = now
+        self.last_active = list(active)
+
+
+RESPONDER = Responder()
+
+
+async def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+    url = os.environ["LIVEKIT_URL"]
+    api_key = os.environ["LIVEKIT_API_KEY"]
+    api_secret = os.environ["LIVEKIT_API_SECRET"]
+    room_name = os.environ.get("ARTEMIS_ROOM", "smoke-test")
+    identity = os.environ.get("ARTEMIS_IDENTITY", "artemis")
+    greeting = os.environ.get(
+        "ARTEMIS_GREETING",
+        "Greetings. ARTEMIS online. Systems nominal.",
+    )
+
+    token = (
+        api.AccessToken(api_key, api_secret)
+        .with_identity(identity)
+        .with_name("ARTEMIS")
+        .with_grants(
+            api.VideoGrants(
+                room_join=True,
+                room=room_name,
+                can_publish=True,
+                can_subscribe=True,
+                can_publish_data=True,
+            )
+        )
+        .to_jwt()
+    )
+
+    room = rtc.Room()
+
+    @room.on("participant_connected")
+    def _on_join(p: rtc.RemoteParticipant) -> None:
+        log.info("joined: %s", p.identity)
+        STATE.log_event(f"JOIN {p.identity}")
+        refresh_participants(room)
+
+    @room.on("participant_disconnected")
+    def _on_leave(p: rtc.RemoteParticipant) -> None:
+        STATE.log_event(f"LEAVE {p.identity}")
+        refresh_participants(room)
+
+    @room.on("active_speakers_changed")
+    def _on_speakers(speakers: list[rtc.Participant]) -> None:
+        active = [s.identity for s in speakers]
+        STATE.set_active(active)
+        RESPONDER.update(active)
+
+    await room.connect(url, token)
+    refresh_participants(room)
+    log.info("connected to %s as %s (room=%s)", url, identity, room_name)
+    STATE.log_event("SYSTEM ONLINE")
+
+    tts_thread = threading.Thread(target=_tts_worker, daemon=True)
+    tts_thread.start()
+    text_queue.put(greeting)
+
+    v_source = rtc.VideoSource(W, H)
+    v_track = rtc.LocalVideoTrack.create_video_track("artemis-face", v_source)
+    # Simulcast: publisher sends 3 resolution layers, SFU routes the
+    # right layer to each subscriber based on viewport + bandwidth.
+    # Browser side has adaptiveStream + dynacast enabled (table.js), so
+    # inactive layers are automatically paused — net CPU cost is small.
+    # Top-layer cap is 2 Mbps at 960×720 @ 30 fps; LiveKit auto-derives
+    # lower layers from that.
+    video_opts = rtc.TrackPublishOptions(
+        source=rtc.TrackSource.SOURCE_CAMERA,
+        simulcast=True,
+        video_encoding=rtc.VideoEncoding(
+            max_framerate=FPS,
+            max_bitrate=2_000_000,
+        ),
+    )
+    await room.local_participant.publish_track(v_track, video_opts)
+
+    a_source = rtc.AudioSource(AUDIO_SR, AUDIO_CHANNELS)
+    a_track = rtc.LocalAudioTrack.create_audio_track("artemis-voice", a_source)
+    await room.local_participant.publish_track(
+        a_track, rtc.TrackPublishOptions(source=rtc.TrackSource.SOURCE_MICROPHONE)
+    )
+    log.info("published video + audio tracks")
+
+    await room.local_participant.publish_data(
+        json.dumps({"kind": "artemis.say", "text": "(ARTEMIS online.)"}).encode(),
+        reliable=True,
+    )
+
+    running = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            loop.add_signal_handler(sig, running.set)
+        except NotImplementedError:
+            pass
+
+    try:
+        await asyncio.gather(
+            _video_publisher(v_source, running),
+            _audio_publisher(a_source, running),
+        )
+    finally:
+        text_queue.put(None)
+        await room.disconnect()
+        log.info("disconnected cleanly")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(asyncio.run(main()))
+    except KeyboardInterrupt:
+        sys.exit(130)


### PR DESCRIPTION
## Summary

Lands the running ARTEMIS avatar experiment into the repo plus the table UI frame plus the consolidated multi-sprint roadmap.

## What's in the PR

- **Avatar agent** — `src/agi/primer/artemis/livekit_agent/avatar_hud.py` (the HUD running on Atlas). 960×720 @ 30 fps with simulcast, scanlines/dense-grid removed, Piper TTS (Amy voice), canned responder.
- **Systemd unit** — `deploy/systemd/atlas-artemis-avatar.service`.
- **Table web UI** — `deploy/web/table/` (index.html, table.css, table.js, vendor README). Three-card layout: avatar, info/session/log, artifacts. Replaces meet.livekit.io.
- **Roadmap** — `docs/ARTEMIS_AVATAR_ROADMAP.md` (older phase doc, kept for continuity).
- **Sprint plan** — `docs/ARTEMIS_SPRINT_PLAN.md` (the consolidated 11-sprint roadmap).

## Test plan

- [x] ruff + black clean
- [x] Avatar agent running on Atlas (PID visible via `systemctl status`)
- [x] Web UI connects via `wss://atlas-sjsu.duckdns.org/livekit` and shows ARTEMIS video/audio
- [ ] CI

## Next

S1 (real responsiveness) on its own branch: Whisper ASR, NATS wire to Phase 2 Primer, Keeper approval-gate UI, **Coqui XTTS-v2 voice upgrade**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)