### PR TITLE
add image build/publish workflow for artemis pilot

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -1,0 +1,132 @@
+name: Build & Publish Images
+
+# Builds agi-hpc container images and publishes them to GHCR so that
+# Kubernetes/SLURM deployments can pin to a specific git SHA or semver
+# tag. Scoped today to the ARTEMIS LiveKit agent (pilot); the matrix
+# below is structured so additional services can be added by appending
+# new entries once their Dockerfile build contexts are cleaned up.
+#
+# Tagging strategy (see docs/HPC_DEPLOYMENT.md "Container image publishing"):
+#   - sha-<7char>   every push to main (immutable; what production pins to)
+#   - vX.Y.Z / .Y / .X   on semver git tags (immutable releases)
+#   - latest        only on semver tag pushes
+#   - edge          tip of main
+#   - pr-<n>        PRs (build only, never pushed)
+#
+# Admin prerequisites:
+#   - Settings > Actions > General > Workflow permissions: Read and write
+#   - GHCR package visibility (public, or attach an imagePullSecret in the
+#     consuming K8s namespace)
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*.*.*"]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  OWNER: ahb-sjsu
+  PYTHON_VERSION: "3.12"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  test:
+    name: Tests & Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -e ".[dev]"
+
+      - name: Lint (ruff)
+        run: ruff check src/ tests/ --select F --ignore F401 --extend-exclude "*/__init__.py"
+
+      - name: Format check (black)
+        run: black --check src/ tests/ --exclude "proto_gen"
+
+      - name: Unit tests
+        run: |
+          pytest tests/unit/ -v --tb=short -q \
+            --ignore=tests/unit/test_safety_proto.py \
+            --ignore=tests/unit/test_erisml_proto.py \
+            --ignore=tests/unit/test_safety_gateway.py \
+            --ignore=tests/unit/test_hohfeld.py \
+            --ignore=tests/unit/test_moral_tensor.py \
+            --ignore=tests/unit/test_safety_adapter.py \
+            --ignore=tests/unit/test_safety_learning.py \
+            --ignore=tests/unit/test_safety_gateway_unit.py \
+            --ignore=tests/unit/test_llm_integration.py \
+            --ignore=tests/unit/test_llm_reflection.py \
+            --ignore=tests/unit/test_dht_security.py \
+            -k "not proto and not TestEmbeddingCodecTQ"
+
+  build:
+    name: Build ${{ matrix.name }}
+    needs: test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: artemis-livekit-agent
+            dockerfile: deploy/docker/artemis-livekit-agent/Dockerfile
+            context: .
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      # PRs build but never push - this validates Dockerfile changes
+      # without polluting the registry. Login is skipped on PRs.
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.name }}
+          tags: |
+            type=sha,prefix=sha-,format=short
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=edge,enable={{is_default_branch}}
+          labels: |
+            org.opencontainers.image.title=${{ matrix.name }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+
+      - name: Build (and push on main/tags)
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,scope=${{ matrix.name }},mode=max

--- a/deploy/docker/artemis-livekit-agent/README.md
+++ b/deploy/docker/artemis-livekit-agent/README.md
@@ -8,21 +8,39 @@ Atlas's NATS bus.
 Superseded the Zoom-Meeting-SDK approach on 2026-04-22. See
 `docs/ARTEMIS.md` §11 Phase 3 and §13 decision #6 for rationale.
 
-## Build
+## Images (built by CI)
+
+Production images are built and pushed by
+[`.github/workflows/build-images.yaml`](../../../.github/workflows/build-images.yaml)
+to `ghcr.io/ahb-sjsu/artemis-livekit-agent`. Pull a specific build:
+
+```bash
+# Pin to an immutable git SHA (recommended for production manifests)
+docker pull ghcr.io/ahb-sjsu/artemis-livekit-agent:sha-<7char>
+
+# Or a semver release
+docker pull ghcr.io/ahb-sjsu/artemis-livekit-agent:v0.1.0
+```
+
+See [`docs/HPC_DEPLOYMENT.md`](../../../docs/HPC_DEPLOYMENT.md#container-image-publishing)
+for the full tag scheme and which tag to use in which environment.
+
+### Local build (dev only)
+
+If you need to build locally for a smoke test before pushing, build is
+straightforward CUDA + Python — no C++ SDK, no xvfb, no display:
 
 ```bash
 # From repo root:
 docker buildx build \
   --platform linux/amd64 \
-  -t ghcr.io/ahb-sjsu/artemis-livekit-agent:$(git describe --tags --always) \
+  -t artemis-livekit-agent:dev \
   -f deploy/docker/artemis-livekit-agent/Dockerfile \
   .
-
-docker push ghcr.io/ahb-sjsu/artemis-livekit-agent:<tag>
 ```
 
-Build is straightforward CUDA + Python — no C++ SDK, no xvfb, no
-display. One pip install and we're done.
+Do not push manually-built images to GHCR — let CI own the published
+tags so the registry stays in sync with git.
 
 ## Run (local smoke, against Atlas LiveKit)
 

--- a/docs/HPC_DEPLOYMENT.md
+++ b/docs/HPC_DEPLOYMENT.md
@@ -93,6 +93,100 @@ flowchart TB
 
 </details>
 
+## Container image publishing
+
+Container images for agi-hpc services are built and published by CI
+(see [`.github/workflows/build-images.yaml`](../.github/workflows/build-images.yaml)).
+The pilot today publishes the ARTEMIS LiveKit agent; other services
+will be added to the same workflow as their build contexts are
+cleaned up.
+
+All images live under `ghcr.io/ahb-sjsu/<service-name>`. For example:
+
+```
+ghcr.io/ahb-sjsu/artemis-livekit-agent:sha-7c3aa12
+ghcr.io/ahb-sjsu/artemis-livekit-agent:v0.1.0
+```
+
+### Tag scheme
+
+Every push produces multiple tags. Pick the one that matches your
+environment:
+
+| Tag form | Example | When it's published | Use for |
+|---|---|---|---|
+| `sha-<7char>` | `sha-7c3aa12` | Every push to `main` | **Production** - immutable, lets you pin and roll back to a specific build |
+| `vX.Y.Z` | `v0.1.0` | Push of a git tag `vX.Y.Z` | Production releases |
+| `vX.Y`, `vX` | `v0.1`, `v0` | Push of a git tag `vX.Y.Z` | Staging that wants to float within a minor/major |
+| `latest` | `latest` | Push of a semver git tag only | Convenience; **never pin production to this** |
+| `edge` | `edge` | Tip of `main` | Dev/staging that tracks `main` |
+| `main` | `main` | Tip of `main` | Same as `edge` |
+| `pr-<n>` | `pr-42` | Pull requests (build-only) | Not pushed - PR builds validate Dockerfile changes without polluting the registry |
+
+**Rule of thumb**: production manifests pin to `sha-<7char>` or
+`vX.Y.Z`. Anything else is for non-prod.
+
+### Pinning in Kubernetes manifests
+
+The existing pattern in [`deploy/k8s/artemis-livekit-agent/job.yaml`](../deploy/k8s/artemis-livekit-agent/job.yaml)
+uses `envsubst` to inject the tag at apply time:
+
+```bash
+export ARTEMIS_IMAGE_TAG=sha-7c3aa12   # or v0.1.0
+envsubst < deploy/k8s/artemis-livekit-agent/job.yaml | kubectl apply -f -
+```
+
+To find the SHA for a given commit:
+
+```bash
+git rev-parse --short=7 <commit-or-branch>
+```
+
+### Rollback
+
+Rolling back is a one-line change to the tag:
+
+```bash
+# Re-deploy with the previous SHA
+export ARTEMIS_IMAGE_TAG=sha-<previous>
+envsubst < deploy/k8s/artemis-livekit-agent/job.yaml | kubectl apply -f -
+```
+
+Because every SHA tag is immutable, the previously-running image is
+always available in the registry until it's pruned by retention policy.
+Record the active tag in your deployment runbook (or annotate the
+`Deployment` with it) so the previous SHA is easy to find under
+pressure.
+
+### SLURM / Apptainer
+
+SLURM consumers can pull the same OCI image directly:
+
+```bash
+apptainer pull --force artemis.sif \
+  docker://ghcr.io/ahb-sjsu/artemis-livekit-agent:sha-7c3aa12
+```
+
+Wiring this into the `sbatch` scripts in
+[`infra/hpc/slurm/`](../infra/hpc/slurm/) is tracked as a follow-up.
+
+### Admin setup (one-time)
+
+The CI workflow pushes to GHCR using the built-in `GITHUB_TOKEN`, but a
+repository admin needs to enable a few things before the first push
+succeeds:
+
+- **Workflow write permission**: Settings - Actions - General -
+  Workflow permissions - "Read and write permissions".
+- **Package visibility**: After the first push, the GHCR package is
+  private by default. Either make it public (preferred for an academic
+  project), or create an `imagePullSecret` in each consuming
+  Kubernetes namespace.
+- **Cluster egress**: Confirm NRP / SLURM nodes can reach `ghcr.io`.
+- **First semver tag**: Cut `v0.1.0` once the workflow has built at
+  least one successful `main` build, to validate the semver tag path
+  end-to-end.
+
 ## Prerequisites
 
 ### Hardware Requirements


### PR DESCRIPTION
Adds a CI pipeline that automatically builds and publishes the ARTEMIS LiveKit agent container image to GHCR whenever code is pushed to `main` or a release tag. Every image is tagged with its git SHA so production deployments can pin to a specific build and roll back in one line. Scoped as a pilot — once this is verified working, the same workflow can be extended to the other service images.

Closes #32 


- **Added `.github/workflows/build-images.yaml`** — a new GitHub Actions workflow that runs the existing tests, then builds the ARTEMIS image and pushes it to `ghcr.io/ahb-sjsu/artemis-livekit-agent`. PRs build the image (to catch broken Dockerfile changes) but skip the push. The workflow uses a matrix so adding more services later is just one block of YAML.
- **Set up the tag scheme** via `docker/metadata-action`. Each image gets:
  - `sha-<7char>` on every push to main (immutable — what production pins to)
  - `vX.Y.Z`, `vX.Y`, `vX`, and `latest` when a `v*.*.*` git tag is pushed
  - `edge` for the tip of main
- **Updated `deploy/docker/artemis-livekit-agent/README.md`** — replaced the manual `docker buildx` instructions with a "pull from CI" section. Manual build is kept as a dev-only smoke option.
- **Added a "Container image publishing" section to `docs/HPC_DEPLOYMENT.md`** — covers the tag scheme, how to pin in K8s manifests, the rollback procedure, the Apptainer pull command for SLURM users, and the admin setup checklist.
- 
**Admin actions:**

- [ ] Enable **Settings → Actions → General → Workflow permissions → "Read and write permissions"** so the workflow can push to GHCR.
- [ ] After the first successful push, set GHCR package visibility (public, or attach an `imagePullSecret` to the consuming K8s namespace).
- [ ] Confirm NRP / cluster egress to `ghcr.io` is allowed.
- [ ] Once `main` has a green build, cut a `v0.1.0` git tag to validate the semver release path.

**Follow-up PRs :**

- Fix the broken `COPY ../../` paths in the 9 HPC service Dockerfiles under `infra/hpc/docker/` so they can be added to the build matrix.
- Wire the SLURM `sbatch` scripts in `infra/hpc/slurm/` to `apptainer pull` from GHCR (currently documented but not implemented).
- Optional: add cosign signing and SBOM attestation.

## Test plan

- [ ] PR build runs and passes (validates the workflow YAML + that the Dockerfile still builds on Linux).
- [ ] After merge, confirm `ghcr.io/ahb-sjsu/artemis-livekit-agent:sha-<short>` and `:edge` appear in the org's packages.
- [ ] After cutting `v0.1.0`, confirm `:v0.1.0` and `:latest` are published.
- [ ] Sanity-pull the image: `docker pull ghcr.io/ahb-sjsu/artemis-livekit-agent:edge`.