### PR TITLE
ErisML: deontic maxim gate (polarity) in the safety layer

### DIFF
--- a/configs/safety_config.yaml
+++ b/configs/safety_config.yaml
@@ -48,9 +48,15 @@ safety:
     enable_strategic: true
     # Governance profile name
     profile: "default"
+    # ErisML gRPC service address (previously hardcoded in service.py)
+    erisml_address: "localhost:50060"
+    # Kantian deontic universalizability gate on the maxim (erisml-lib).
+    # No-op unless the proto stubs carry maxim_action_kind/maxim_polarity.
+    enable_deontic_gate: true
 
   # Port assignments (reference)
   ports:
     service: 50055
+    erisml: 50060
     nats: 4222
     nats_monitor: 8222

--- a/docs/ERISML_API.md
+++ b/docs/ERISML_API.md
@@ -342,6 +342,35 @@ The Bond Index measures deviation from perfect correlative symmetry in Hohfeldia
 - `avoid` - Potentially problematic
 - `forbid` - Action vetoed (hard block)
 
+### Deontic Maxim Gate
+
+ErisML carries a **maxim** extracted by [erisml-compiler](https://github.com/ahb-sjsu/erisml-compiler):
+a coarse Kantian `action_kind` plus a **polarity**. Two `EthicalFactsProto`
+fields transport it:
+
+| field | type | meaning |
+|---|---|---|
+| `maxim_action_kind` | string | e.g. `deceive`, `inflict_harm`, `help`, `protect`; empty = no maxim |
+| `maxim_polarity` | string | `affirmed` or `negated` ("did not promise") |
+
+`facts_builder.PlanStepToEthicalFacts` derives these from a plan step
+(`_derive_maxim`). The service runs them through erisml-lib's
+`erisml.ethics.deontic_gate.evaluate_maxim`, a Kantian universalizability test:
+
+- affirmed **prohibition** (deceive, harm, coerce, …) → **veto** (`DEONTIC_UNIVERSALIZABILITY`)
+- negated prohibition ("did not deceive") → pass
+- affirmed **imperfect duty** (help, protect) → pass
+- negated imperfect duty ("did not help") → **veto** (contradiction in will)
+- merely-permissible / unknown → pass
+
+A veto sets `rights_respect = 0` and contributes a `veto_flags` entry, forcing a
+`forbid` verdict. The gate degrades to a no-op when no maxim is present or
+erisml-lib is not installed.
+
+> **Note:** the `maxim_*` proto fields require regenerating the gRPC stubs from
+> `proto/erisml.proto` (see deployment). Until then `_derive_maxim` is computed
+> but not transported, and the gate stays dormant.
+
 ### Decision Proofs
 
 Hash-chained audit trail for governance compliance:

--- a/proto/erisml.proto
+++ b/proto/erisml.proto
@@ -43,6 +43,13 @@ message EthicalFactsProto {
   // --- Domain-specific extensions ---
   map<string, float> extensions = 100;
 
+  // --- Maxim (Kantian action-under-description, from erisml-compiler) ---
+  // Coarse action label + polarity so the deontic universalizability gate can
+  // run. polarity is "affirmed" or "negated" ("did not promise"). An empty
+  // maxim_action_kind means no maxim was extracted.
+  string maxim_action_kind = 101;
+  string maxim_polarity = 102;
+
   reserved 2 to 9, 14 to 19, 23 to 29, 32 to 39, 42 to 49, 53 to 99;
 }
 

--- a/src/agi/safety/erisml/facts_builder.py
+++ b/src/agi/safety/erisml/facts_builder.py
@@ -172,7 +172,43 @@ class PlanStepToEthicalFacts:
             novel_situation=self._is_novel_situation(step),
         )
 
+        # Maxim (action_kind + polarity) for the deontic universalizability gate.
+        # Guarded: only set when the stubs have been regenerated for the new
+        # proto fields (see proto/erisml.proto maxim_action_kind/maxim_polarity).
+        action_kind, polarity = self._derive_maxim(step)
+        if action_kind and hasattr(facts, "maxim_action_kind"):
+            facts.maxim_action_kind = action_kind
+            facts.maxim_polarity = polarity
+
         return facts
+
+    def _derive_maxim(self, step: plan_pb2.PlanStep) -> tuple[str, str]:
+        """Derive a coarse Kantian maxim (action_kind, polarity) from a step.
+
+        Conservative: emits an empty action_kind unless the step clearly maps to
+        a known kind. Polarity is "negated" when the step refrains from / negates
+        the action (safety tag or a ``negated`` param). Mirrors the action-kind
+        vocabulary in erisml-compiler / erisml-lib's deontic gate.
+        """
+        tool = (step.tool_id or "").lower()
+        tags = set(step.safety_tags)
+        action_kind = ""
+        if step.tool_id in self.harmful_tools or "harm" in tool or "attack" in tool:
+            action_kind = "inflict_harm"
+        elif "deception" in tags or "deceive" in tool or "lie" in tool or "mislead" in tool:
+            action_kind = "deceive"
+        elif "coercion" in tags or "coerce" in tool or "threaten" in tool:
+            action_kind = "coerce"
+        elif "protect" in tool or "protect" in tags or "safeguard" in tags:
+            action_kind = "protect"
+        elif "assist" in tool or "help" in tool:
+            action_kind = "help"
+        negated = (
+            "negated" in tags
+            or "refrain" in tags
+            or str(step.params.get("negated", "")).lower() == "true"
+        )
+        return action_kind, ("negated" if negated else "affirmed")
 
     def _estimate_risks(
         self,

--- a/src/agi/safety/erisml/service.py
+++ b/src/agi/safety/erisml/service.py
@@ -28,7 +28,7 @@ import time
 from concurrent import futures
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import grpc
 
@@ -428,6 +428,29 @@ class ErisMLServicer(erisml_pb2_grpc.ErisMLServiceServicer):
     # Private Methods
     # -----------------------------------------------------------------------
 
+    @staticmethod
+    def _deontic_maxim_veto(facts: "erisml_pb2.EthicalFactsProto") -> Optional[str]:
+        """Run erisml-lib's deontic universalizability gate on the maxim.
+
+        Reads ``maxim_action_kind`` / ``maxim_polarity`` from the facts proto
+        (present once the stubs are regenerated for the new proto fields). A
+        maxim that fails universalizability returns a reason string; otherwise
+        None. Degrades to None when erisml-lib or the fields are unavailable.
+        """
+        action_kind = getattr(facts, "maxim_action_kind", "") or ""
+        if not action_kind:
+            return None
+        polarity = getattr(facts, "maxim_polarity", "") or "affirmed"
+        try:
+            from erisml.ethics.deontic_gate import evaluate_maxim
+            from erisml.ethics.facts import Maxim
+        except Exception:
+            return None
+        result = evaluate_maxim(Maxim(action_kind=action_kind, polarity=polarity))
+        if result.vetoed:
+            return f"deontic_universalizability_fail:{result.action_kind}"
+        return None
+
     def _compute_moral_vector(self, facts: erisml_pb2.EthicalFactsProto) -> MoralVector:
         """Compute moral vector from ethical facts."""
         mv = MoralVector()
@@ -448,6 +471,14 @@ class ErisMLServicer(erisml_pb2_grpc.ErisMLServiceServicer):
             mv.reason_codes.append("rule_violation")
         else:
             mv.rights_respect = 1.0 if facts.has_valid_consent else 0.7
+
+        # Deontic maxim gate: Kantian universalizability (polarity-aware) via
+        # erisml-lib's real gate. No-op if no maxim or erisml-lib is absent.
+        deontic_reason = self._deontic_maxim_veto(facts)
+        if deontic_reason is not None:
+            mv.rights_respect = 0.0
+            mv.veto_flags.append("DEONTIC_UNIVERSALIZABILITY")
+            mv.reason_codes.append(deontic_reason)
 
         # Fairness dimension
         if facts.discriminates_on_protected_attr:

--- a/tests/unit/test_erisml_maxim_gate.py
+++ b/tests/unit/test_erisml_maxim_gate.py
@@ -1,0 +1,87 @@
+# AGI-HPC Project - High-Performance Computing Architecture for AGI
+# Copyright (c) 2025 Andrew H. Bond
+# Contact: agi.hpc@gmail.com
+#
+# Licensed under the AGI-HPC Responsible AI License v1.0.
+# You may obtain a copy of the License at the root of this repository,
+# or by contacting the author(s).
+
+"""Tests for the deontic maxim gate wiring in the ErisML integration.
+
+Maxim derivation (PlanStep -> action_kind/polarity) and the universalizability
+veto (via erisml-lib's deontic gate). Skips cleanly where the generated proto
+stubs or erisml-lib are unavailable (e.g. a dev box without grpcio>=1.80).
+"""
+from __future__ import annotations
+
+import types
+
+import pytest
+
+# These imports pull in the generated stubs; skip the module if they can't load.
+facts_builder = pytest.importorskip("agi.safety.erisml.facts_builder")
+service = pytest.importorskip("agi.safety.erisml.service")
+plan_pb2 = pytest.importorskip("agi.proto_gen.plan_pb2")
+
+
+def _step(tool_id: str = "noop", safety_tags=None, params=None) -> "plan_pb2.PlanStep":
+    step = plan_pb2.PlanStep(step_id="s1", tool_id=tool_id)
+    for t in safety_tags or []:
+        step.safety_tags.append(t)
+    for k, v in (params or {}).items():
+        step.params[k] = v
+    return step
+
+
+# ----------------------------------------------------- maxim derivation
+
+
+def test_derive_maxim_harmful_tool_is_inflict_harm():
+    b = facts_builder.PlanStepToEthicalFacts()
+    tool = sorted(facts_builder.HARMFUL_TOOLS)[0]
+    action_kind, polarity = b._derive_maxim(_step(tool_id=tool))
+    assert action_kind == "inflict_harm"
+    assert polarity == "affirmed"
+
+
+def test_derive_maxim_negation_tag():
+    b = facts_builder.PlanStepToEthicalFacts()
+    _, polarity = b._derive_maxim(_step(tool_id="deceive_user", safety_tags=["negated"]))
+    assert polarity == "negated"
+
+
+def test_derive_maxim_unknown_is_empty():
+    b = facts_builder.PlanStepToEthicalFacts()
+    action_kind, _ = b._derive_maxim(_step(tool_id="noop"))
+    assert action_kind == ""
+
+
+# ----------------------------------------------------- deontic veto
+
+
+def _has_erisml_lib() -> bool:
+    try:
+        import erisml.ethics.deontic_gate  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _has_erisml_lib(), reason="erisml-lib not installed")
+def test_deontic_veto_fires_for_prohibition():
+    facts = types.SimpleNamespace(maxim_action_kind="deceive", maxim_polarity="affirmed")
+    reason = service.ErisMLServicer._deontic_maxim_veto(facts)
+    assert reason is not None
+    assert "deontic_universalizability_fail" in reason
+
+
+@pytest.mark.skipif(not _has_erisml_lib(), reason="erisml-lib not installed")
+def test_deontic_veto_silent_for_negated_prohibition():
+    facts = types.SimpleNamespace(maxim_action_kind="deceive", maxim_polarity="negated")
+    assert service.ErisMLServicer._deontic_maxim_veto(facts) is None
+
+
+@pytest.mark.skipif(not _has_erisml_lib(), reason="erisml-lib not installed")
+def test_deontic_veto_silent_when_no_maxim():
+    facts = types.SimpleNamespace(maxim_action_kind="", maxim_polarity="affirmed")
+    assert service.ErisMLServicer._deontic_maxim_veto(facts) is None


### PR DESCRIPTION
Backports the erisml-compiler maxim/polarity model + erisml-lib's deontic gate into the AGI-HPC ErisML integration (Safety subsystem, :50060).

- **proto/erisml.proto** — `EthicalFactsProto.maxim_action_kind` (101) + `maxim_polarity` (102), backward-compatible. **Requires regenerating gRPC stubs at deploy time.**
- **facts_builder.py** — `_derive_maxim()` maps a PlanStep → coarse Kantian `action_kind` + polarity; sets the new fields (guarded by `hasattr`, no-op on un-regenerated stubs).
- **service.py** — `_compute_moral_vector` consults erisml-lib's `deontic_gate.evaluate_maxim`; a maxim that fails universalizability adds a `DEONTIC_UNIVERSALIZABILITY` veto → `forbid`. No-op without a maxim or erisml-lib.
- **configs/safety_config.yaml** — document `erisml_address` (:50060, was hardcoded), add erisml port + `enable_deontic_gate`.
- **docs/ERISML_API.md** — maxim fields + deontic gate semantics.
- **tests/unit/test_erisml_maxim_gate.py** — derivation + veto (guarded `importorskip` for envs without grpcio≥1.80 / erisml-lib).

Stubs intentionally **not** regenerated in-repo (the committed stub pins grpcio≥1.80 / protobuf 6.31; regenerating off a mismatched dev box risks breaking the live service). Regen happens on Atlas at deploy — steps to follow. README/ARCHITECTURE_OVERVIEW one-liners deferred to `bds2026-camera-ready` (mid-rewrite there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)