### PR TITLE
Fix CI: guard erisml-lib-dependent I-EIP tests with importorskip

### DIFF
--- a/tests/unit/test_ieip_dashboard.py
+++ b/tests/unit/test_ieip_dashboard.py
@@ -12,6 +12,8 @@ import time
 
 import pytest
 
+pytest.importorskip("erisml")  # ieip_dashboard pulls in erisml-lib (optional)
+
 from agi.safety.ieip_dashboard import (
     build_status,
     load_status,

--- a/tests/unit/test_ieip_monitor.py
+++ b/tests/unit/test_ieip_monitor.py
@@ -17,6 +17,8 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+
+pytest.importorskip("erisml")  # I-EIP monitor depends on erisml-lib (optional)
 from erisml.ieip.adapters import APIPassthroughAdapter, detect_adapter
 
 from agi.safety.ieip_monitor import (


### PR DESCRIPTION
`test_ieip_monitor.py` and `test_ieip_dashboard.py` import erisml-lib (which agi-hpc CI doesn't install), causing collection errors that interrupted the whole unit-test suite. Guard both with `pytest.importorskip('erisml')` so they skip gracefully when the optional dep is absent — matching the maxim-gate test and `deme_gateway`'s existing try/except pattern. Lint (black --exclude proto_gen, ruff F) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)