### PR TITLE
feat(safety): DCGM forward-pass attestation in check_output (rebased #90)

### DIFF
--- a/src/agi/safety/deme_gateway.py
+++ b/src/agi/safety/deme_gateway.py
@@ -33,6 +33,7 @@ Phase 3 (Safety Gateway) -- Atlas integration.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import logging
 import re
@@ -463,6 +464,20 @@ class SafetyGateway:
         self._log_decision(result, f"gpu{gpu_index} {mode}")
         return result
 
+    @contextlib.contextmanager
+    def forward_pass_attestation(self, gpu_index: int = 0):
+        """Context manager to capture DCGM snapshots around a forward pass.
+
+        Yields a dict mapping {"before": GPUSnapshot, "after": GPUSnapshot}.
+        Pass this dict unpacked into `check_output`.
+        """
+        attestor = self._get_attestor(gpu_index)
+        snapshots = {"before": attestor.snapshot(), "after": None}
+        try:
+            yield snapshots
+        finally:
+            snapshots["after"] = attestor.snapshot()
+
     def _publish_attestation_event(
         self,
         *,
@@ -589,15 +604,25 @@ class SafetyGateway:
         response: str,
         user_message: str = "",
         context: Optional[Dict[str, Any]] = None,
+        gpu_before_snapshot: Optional[Any] = None,
+        gpu_after_snapshot: Optional[Any] = None,
+        gpu_trace_samples: Optional[List[Dict[str, Any]]] = None,
+        gpu_index: int = 0,
     ) -> SafetyResult:
         """Post-LLM output gate.
 
         Runs full DEME pipeline on LLM output before it reaches the user.
+        Optionally performs hardware-level attestation that a true forward
+        pass occurred, preventing cache replay attacks (Axiom 4).
 
         Args:
             response: LLM-generated response text.
             user_message: Original user input (for context).
             context: Optional context dict.
+            gpu_before_snapshot: DCGM snapshot taken before forward pass.
+            gpu_after_snapshot: DCGM snapshot taken after forward pass.
+            gpu_trace_samples: Optional full power trace.
+            gpu_index: GPU index for attestation logging.
 
         Returns:
             SafetyResult indicating whether the output is safe.
@@ -605,6 +630,41 @@ class SafetyGateway:
         t0 = time.perf_counter()
         ctx = context or {}
         proof_layers: List[Dict[str, Any]] = []
+
+        # Layer 0: Hardware Attestation
+        if (
+            gpu_before_snapshot is not None and gpu_after_snapshot is not None
+        ) or gpu_trace_samples is not None:
+            att_result = self.check_hardware_attestation(
+                before=gpu_before_snapshot,
+                after=gpu_after_snapshot,
+                trace_samples=gpu_trace_samples,
+                gpu_index=gpu_index,
+                context=ctx,
+            )
+
+            # Format decision proof inline with DEME gateway layers
+            att_proof = att_result.decision_proof.copy()
+            att_proof["layer"] = "hardware_attestation"
+            att_proof["vetoed"] = not att_result.passed
+            att_proof["flags"] = att_result.flags
+            att_proof["score"] = att_result.score
+            att_proof["latency_ms"] = att_result.latency_ms
+            proof_layers.append(att_proof)
+
+            # Fail immediately if attestation fails
+            if not att_result.passed:
+                latency_ms = (time.perf_counter() - t0) * 1000.0
+                result = SafetyResult(
+                    passed=False,
+                    score=0.0,
+                    flags=att_result.flags,
+                    decision_proof=self._build_proof("output", proof_layers, response),
+                    gate="output",
+                    latency_ms=latency_ms,
+                )
+                self._log_decision(result, response)
+                return result
 
         # Layer 1: Reflex on response
         reflex_result = self._run_reflex(response, "output")

--- a/tests/unit/test_deme_gateway_attestation.py
+++ b/tests/unit/test_deme_gateway_attestation.py
@@ -230,3 +230,50 @@ def test_attestation_with_real_trace_fixture():
     r2 = gw.check_hardware_attestation(trace_samples=idle)
     assert r2.passed is False
     assert "attestation_failed" in r2.flags
+
+
+# ── #90: forward-pass attestation context manager + check_output Layer 0 ──
+
+
+class _SnapStubAttestor(_StubAttestor):
+    """Stub that also serves DCGM snapshots for forward_pass_attestation."""
+
+    def __init__(self, *args, snapshots=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._snapshots = list(snapshots or [])
+        self.snapshot_calls = 0
+
+    def snapshot(self):
+        self.snapshot_calls += 1
+        return self._snapshots.pop(0) if self._snapshots else MagicMock()
+
+
+def test_forward_pass_attestation_captures_before_and_after():
+    """The context manager snapshots before entry and after exit."""
+    s_before, s_after = MagicMock(name="before"), MagicMock(name="after")
+    stub = _SnapStubAttestor(available=True, snapshots=[s_before, s_after])
+    gw = SafetyGateway(dcgm_attestor=stub)
+
+    with gw.forward_pass_attestation(gpu_index=0) as snaps:
+        assert snaps["before"] is s_before
+        assert snaps["after"] is None  # not captured until the block exits
+
+    assert snaps["after"] is s_after
+    assert stub.snapshot_calls == 2
+
+
+def test_check_output_layer0_attestation_failure_vetoes():
+    """A failed hardware attestation short-circuits check_output with
+    passed=False before the rest of the pipeline runs (cache-replay defense)."""
+    stub = _StubAttestor(available=True, attest_result=_fail_result("no power delta"))
+    gw = SafetyGateway(dcgm_attestor=stub)
+
+    r = gw.check_output(
+        response="hello world",
+        gpu_before_snapshot=MagicMock(),
+        gpu_after_snapshot=MagicMock(),
+    )
+    assert r.passed is False
+    assert r.gate == "output"
+    assert "attestation_failed" in r.flags
+    assert len(stub.attest_calls) == 1  # Layer 0 actually consulted attestation


### PR DESCRIPTION
Rebases and lands the substantive part of #90 (@hashiim0206) onto current `main`.

## What's included
- `SafetyGateway.forward_pass_attestation()` — context manager that snapshots DCGM state around a forward pass.
- Optional **Layer-0 hardware attestation** in `check_output()` — when before/after GPU snapshots (or a power trace) are supplied, a failed attestation short-circuits the output gate (cache-replay defense). Backward-compatible: with no snapshots, behavior is unchanged.

## What's dropped vs #90
- #90's `dcgm_attestation.py` parser change — **superseded by #84**, which already handles the `GPU <idx>` prefix (with a test). That was the only merge conflict.

## CI
- Added unit tests (`test_deme_gateway_attestation.py`): the context manager + the Layer-0 veto path, using the existing stubbed-attestor pattern (no GPU).
- ruff (F) + black verified locally; pytest runs under CI.

Closes #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)