### PR TITLE
ci: add ty type-check (advisory)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,12 @@ jobs:
       - name: Format check (black)
         run: black --check src/ tests/ --exclude "proto_gen"
 
+      - name: Type check (ty — advisory)
+        continue-on-error: true  # ty is preview (0.0.x); advisory until src is ty-clean
+        run: |
+          pip install ty==0.0.55
+          ty check src
+
       - name: Unit tests
         run: |
           pytest tests/unit/ -v --tb=short -q \


### PR DESCRIPTION
Adds Astral's `ty` as a non-blocking advisory step (continue-on-error) after the black format check, scoped to `src`. ~888 diagnostics currently; reports in CI logs without failing the build. Make blocking once src is ty-clean.